### PR TITLE
feat: use fancy URLs for premium users' profile pages

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -318,7 +318,7 @@
 
         <mat-nav-list>
           @if(app.authenticated()) {
-          <a mat-list-item [routerLink]="['/p', accountState.pubkey()]" (click)="toggleProfileSidenav()">
+          <a mat-list-item [routerLink]="accountState.profilePath()" (click)="toggleProfileSidenav()">
             <mat-icon matListItemIcon>person</mat-icon>
             <span>My Profile</span>
           </a>

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -32,6 +32,27 @@ import { MediaQueueComponent } from './pages/media-queue/media-queue.component';
 import { EventPageComponent } from './pages/event/event.component';
 import { NotificationManageComponent } from './pages/notifications/manage/manage.component';
 import { DataResolver } from './data-resolver';
+import { UsernameResolver } from './usernameResolver';
+
+const profileChildren: Routes = [
+  {
+    path: '',
+    component: ProfileHomeComponent,
+    children: [
+      { path: '', redirectTo: 'notes', pathMatch: 'full' },
+      { path: 'notes', component: ProfileNotesComponent },
+      { path: 'replies', component: ProfileRepliesComponent },
+      { path: 'reads', component: ProfileReadsComponent },
+      { path: 'media', component: ProfileMediaComponent }
+    ]
+  },
+  { path: 'about', component: ProfileAboutComponent },
+  { path: 'edit', component: ProfileEditComponent },
+  { path: 'connections', component: ProfileConnectionsComponent },
+  { path: 'following', component: FollowingComponent },
+  { path: 'relays', component: ProfileRelaysComponent },
+  { path: 'details', component: DetailsComponent }
+];
 
 export const routes: Routes = [
   { path: '', component: FeedsComponent, pathMatch: 'full' },
@@ -67,25 +88,13 @@ export const routes: Routes = [
     path: 'p/:id',
     component: ProfileComponent,
     resolve: { data: DataResolver },
-    children: [
-      {
-        path: '',
-        component: ProfileHomeComponent,
-        children: [
-          { path: '', redirectTo: 'notes', pathMatch: 'full' },
-          { path: 'notes', component: ProfileNotesComponent },
-          { path: 'replies', component: ProfileRepliesComponent },
-          { path: 'reads', component: ProfileReadsComponent },
-          { path: 'media', component: ProfileMediaComponent }
-        ]
-      },
-      { path: 'about', component: ProfileAboutComponent },
-      { path: 'edit', component: ProfileEditComponent },
-      { path: 'connections', component: ProfileConnectionsComponent },
-      { path: 'following', component: FollowingComponent },
-      { path: 'relays', component: ProfileRelaysComponent },
-      { path: 'details', component: DetailsComponent }
-    ]
+    children: profileChildren,
+  },
+  {
+    path: 'u/:username',
+    component: ProfileComponent,
+    resolve: { data: UsernameResolver },
+    children: profileChildren,
   },
   {
     path: 'premium',

--- a/src/app/services/account-state.service.ts
+++ b/src/app/services/account-state.service.ts
@@ -7,7 +7,7 @@ import { DataService } from './data.service';
 import { StorageService } from './storage.service';
 import { NostrService, NostrUser } from './nostr.service';
 import { AccountService } from '../api/services';
-import { Account } from '../api/models';
+import { Account, Feature } from '../api/models';
 import { Subject, takeUntil } from 'rxjs';
 import { HttpContext } from '@angular/common/http';
 import { USE_NIP98 } from './interceptors/nip98Auth';
@@ -62,6 +62,23 @@ export class AccountStateService {
   profile = signal<NostrRecord | undefined>(undefined);
 
   accountSubscription = signal<Account | undefined>(undefined);
+
+  profilePath = computed(() => {
+    const sub = this.accountSubscription();
+    const username = sub?.username;
+    if (username && this.hasFeature('USERNAME' as Feature)) {
+      return `/u/${username}`;
+    } else {
+      return `/p/${this.npub()}`;
+    }
+  });
+
+  hasFeature(feature: Feature): boolean {
+    const sub = this.accountSubscription();
+    if (!sub) return false;
+    const features = (sub.entitlements?.features || []) as any as Feature[];
+    return features.includes(feature);
+  }
 
   changeAccount(account: NostrUser | null): void {
     this.accountChanging.set(account?.pubkey || '');

--- a/src/app/services/layout.service.ts
+++ b/src/app/services/layout.service.ts
@@ -892,11 +892,18 @@ export class LayoutService implements OnDestroy {
     }
 
     shareProfileUrl(npub: string | null | undefined): void {
-        if (!npub) {
+        const username = this.accountStateService.accountSubscription()?.username;
+
+        if (!npub && !username) {
             return;
         }
 
-        let url = 'https://nostria.app/p/' + npub;
+        let url;
+        if (username) {
+            url = 'https://nostria.app/u/' + username;
+        } else {
+            url = 'https://nostria.app/p/' + npub;
+        }
         this.copyToClipboard(url, 'profile URL');
     }
 

--- a/src/app/usernameResolver.ts
+++ b/src/app/usernameResolver.ts
@@ -1,0 +1,21 @@
+import { inject, Injectable } from "@angular/core";
+import { ActivatedRouteSnapshot, Resolve } from "@angular/router";
+import { AccountService } from "./api/services";
+import { map, Observable } from "rxjs";
+
+
+@Injectable({ providedIn: 'root' })
+export class UsernameResolver implements Resolve<{ id: string | undefined, username: string }> {
+    accountService = inject(AccountService)
+
+    constructor() {
+
+    }
+
+    resolve(route: ActivatedRouteSnapshot): Observable<{ id: string | undefined, username: string }> {
+        const username = route.params['username'];
+        return this.accountService.getPublicAccount({ pubkeyOrUsername: username })
+            .pipe(map(publicProfile => ({ id: publicProfile.result?.pubkey, username })))
+
+    }
+}

--- a/src/app/usernameResolver.ts
+++ b/src/app/usernameResolver.ts
@@ -8,9 +8,6 @@ import { map, Observable } from "rxjs";
 export class UsernameResolver implements Resolve<{ id: string | undefined, username: string }> {
     accountService = inject(AccountService)
 
-    constructor() {
-
-    }
 
     resolve(route: ActivatedRouteSnapshot): Observable<{ id: string | undefined, username: string }> {
         const username = route.params['username'];


### PR DESCRIPTION
E.g. if the user have taken username "bob" upon premium signup, his profile page should be visible by /u/bob

Technical notes:
- path `/u/:username` is added to the router to be rendered with the same Profile component as /p/:pubkey. The difference is that `/u/:username` router uses `UsernameResolver` which resolves pubkey by username and puts the resolved value in route data
- changed Profile component to work for both `/p/:pubkey` (old behavior) and `/u/:username`. For that, I'm checking in the component if there is a route data with "id" and "username". If yes, it means it renders `/u/:username` path.
- changed "Share Profile URL" handler to generate /u/:username link for premium guys