### PR TITLE
chore: adjust payment API to the latest version

### DIFF
--- a/src/app/api/models/create-payment-request.ts
+++ b/src/app/api/models/create-payment-request.ts
@@ -10,11 +10,6 @@ export interface CreatePaymentRequest {
   billingCycle: 'monthly' | 'quarterly' | 'yearly';
 
   /**
-   * Price in USD cents
-   */
-  price: number;
-
-  /**
    * User's public key in hex format (64 lowercase hex chars, not npub)
    */
   pubkey: string;

--- a/src/app/pages/premium/upgrade/upgrade.component.ts
+++ b/src/app/pages/premium/upgrade/upgrade.component.ts
@@ -197,7 +197,6 @@ export class UpgradeComponent implements OnDestroy {
         body: {
           billingCycle: selectedPaymentOption,
           tierName: selectedTier.details.tier,
-          price: selectedPrice,
           pubkey,
         }
       }


### PR DESCRIPTION
Price is not passed now in request, instead it is taken from tiers config on the backend

Corresponding backend change: https://github.com/nostria-app/nostria-service/issues/12