### PR TITLE
feat: profile URL doesn't redirect to /notes

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -39,7 +39,7 @@ const profileChildren: Routes = [
     path: '',
     component: ProfileHomeComponent,
     children: [
-      { path: '', redirectTo: 'notes', pathMatch: 'full' },
+      { path: '', component: ProfileNotesComponent },
       { path: 'notes', component: ProfileNotesComponent },
       { path: 'replies', component: ProfileRepliesComponent },
       { path: 'reads', component: ProfileReadsComponent },

--- a/src/app/pages/profile/profile-home/profile-home.component.html
+++ b/src/app/pages/profile/profile-home/profile-home.component.html
@@ -1,7 +1,7 @@
 <nav mat-tab-nav-bar [tabPanel]="tabPanel" mat-stretch-tabs="true" mat-align-tabs="start">
   @for (link of navLinks; track link.path) {
-  <a mat-tab-link [routerLink]="link.path" routerLinkActive #rla="routerLinkActive" [active]="rla.isActive"
-    [queryParamsHandling]="'preserve'">
+  <a mat-tab-link [routerLink]="link.path" routerLinkActive #rla="routerLinkActive"
+    [active]="isLinkActive(link.path, rla.isActive)" [queryParamsHandling]="'preserve'">
     <mat-icon>{{ link.icon }}</mat-icon>
     <span class="nav-link-text">{{ link.label }}</span>
   </a>

--- a/src/app/pages/profile/profile-home/profile-home.component.ts
+++ b/src/app/pages/profile/profile-home/profile-home.component.ts
@@ -39,6 +39,13 @@ export class ProfileHomeComponent {
       // { path: 'following', label: 'Following', icon: 'people' }
     ];
 
+  isLinkActive(path: string, isActive: boolean): boolean {
+    const firstChild = this.route.firstChild?.snapshot.url[0]?.path ?? '';
+    return (
+      isActive || (path === 'notes' && firstChild === '')
+    );
+  }
+
   // We'll get the pubkey from the parent route
   getPubkey(): string {
     return this.route.parent?.snapshot.paramMap.get('id') || '';

--- a/src/app/pages/profile/profile.component.ts
+++ b/src/app/pages/profile/profile.component.ts
@@ -142,17 +142,17 @@ export class ProfileComponent {
 
             // First update URL to have npub in URL.
             if (username) {
-              this.url.updatePathSilently(['/u', username, 'notes']);
+              this.url.updatePathSilently(['/u', username]);
             } else {
               username = await this.username.getUsername(id);
 
               if (username) {
-                this.url.updatePathSilently(['/u', username, 'notes']);
+                this.url.updatePathSilently(['/u', username]);
               }
               else {
                 // If we find event only by ID, we should update the URL to include the NIP-19 encoded value that includes the pubkey.
                 const encoded = nip19.npubEncode(id);
-                this.url.updatePathSilently(['/p', id, 'notes']);
+                this.url.updatePathSilently(['/p', id]);
               }
             }
           } else {
@@ -160,12 +160,12 @@ export class ProfileComponent {
               username = await this.username.getUsername(id);
 
               if (username) {
-                this.url.updatePathSilently(['/u', username, 'notes']);
+                this.url.updatePathSilently(['/u', username]);
               }
               else {
                 // If we find event only by ID, we should update the URL to include the NIP-19 encoded value that includes the pubkey.
                 const encoded = nip19.npubEncode(id);
-                this.url.updatePathSilently(['/p', encoded, 'notes']);
+                this.url.updatePathSilently(['/p', encoded]);
               }
             }
           }


### PR DESCRIPTION
Now /u/username/notes will be in URL only when user explicitly navigated to "Notes" tab in profile. URL /u/username will show profile with active "Notes" tab (as it was before except the url change)

Closes #68 