### PR TITLE
feat: implement reposts for kind:1

### DIFF
--- a/src/app/pages/event/event.component.html
+++ b/src/app/pages/event/event.component.html
@@ -11,9 +11,13 @@
   }
 </div>
 
-@if (reposts()) {
-  <mat-icon>repeat</mat-icon>
-  {{ reposts().length }}
+@if (app.enabledFeature('beta')) {
+  @if (reposts()) {
+    <button matButton (click)="repostNote()">
+      <mat-icon>repeat</mat-icon>
+      <span>{{ reposts().length }}</span>
+    </button>
+  }
 }
 
 @if (error()) {

--- a/src/app/pages/event/event.component.ts
+++ b/src/app/pages/event/event.component.ts
@@ -23,6 +23,8 @@ import { MatButtonModule } from '@angular/material/button';
 import { ApplicationService } from '../../services/application.service';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { EVENT_STATE_KEY, EventData } from '../../data-resolver';
+import { RepostService } from '../../services/repost.service';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 /** Description of the EventPageComponent
  *
@@ -74,6 +76,8 @@ export class EventPageComponent implements OnInit {
   replies = signal<Event[]>([]);
   threadedReplies = signal<ThreadedEvent[]>([]);
   transferState = inject(TransferState);
+  private repostService = inject(RepostService);
+  private snackBar = inject(MatSnackBar);
 
   item!: EventData;
 
@@ -465,5 +469,16 @@ export class EventPageComponent implements OnInit {
     // Navigate to the specific event to view deeper replies
     const encoded = nip19.neventEncode({ id: eventId });
     this.router.navigate(['/e', encoded]);
+  }
+
+  async repostNote(): Promise<void> {
+    const event = this.event();
+    if (!event) return;
+    const published = await this.repostService.repostNote(event);
+    if (published) {
+      this.snackBar.open('Note reposted successfully!', 'Dismiss', {
+        duration: 3000,
+      });
+    }
   }
 }

--- a/src/app/pages/feeds/feeds.component.html
+++ b/src/app/pages/feeds/feeds.component.html
@@ -625,9 +625,11 @@
                           <button mat-icon-button>
                             <mat-icon>comment</mat-icon>
                           </button>
-                          <button mat-icon-button>
-                            <mat-icon>repeat</mat-icon>
-                          </button>
+                          @if (app.enabledFeature('beta')) {
+                            <button mat-icon-button (click)="repostNote(event)">
+                              <mat-icon>repeat</mat-icon>
+                            </button>
+                          }
                         </mat-card-actions>
                       </mat-card>
                     }

--- a/src/app/pages/feeds/feeds.component.ts
+++ b/src/app/pages/feeds/feeds.component.ts
@@ -46,7 +46,7 @@ import {
   ColumnDefinition,
 } from '../../services/feeds-collection.service';
 import { MediaItem, NostrRecord } from '../../interfaces';
-import { Event, kinds, UnsignedEvent } from 'nostr-tools';
+import { Event } from 'nostr-tools';
 import { decode } from 'blurhash';
 import { UserProfileComponent } from '../../components/user-profile/user-profile.component';
 import { UrlUpdateService } from '../../services/url-update.service';

--- a/src/app/pages/feeds/feeds.component.ts
+++ b/src/app/pages/feeds/feeds.component.ts
@@ -46,7 +46,7 @@ import {
   ColumnDefinition,
 } from '../../services/feeds-collection.service';
 import { MediaItem, NostrRecord } from '../../interfaces';
-import { Event } from 'nostr-tools';
+import { Event, kinds, UnsignedEvent } from 'nostr-tools';
 import { decode } from 'blurhash';
 import { UserProfileComponent } from '../../components/user-profile/user-profile.component';
 import { UrlUpdateService } from '../../services/url-update.service';
@@ -54,6 +54,9 @@ import { MediaPlayerService } from '../../services/media-player.service';
 import { MatDividerModule } from '@angular/material/divider';
 import { ContentComponent } from '../../components/content/content.component';
 import { AgoPipe } from '../../pipes/ago.pipe';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { ApplicationService } from '../../services/application.service';
+import { RepostService } from '../../services/repost.service';
 
 interface NavLink {
   id: string;
@@ -109,6 +112,9 @@ export class FeedsComponent implements OnInit, OnDestroy {
   private url = inject(UrlUpdateService);
   private cdr = inject(ChangeDetectorRef);
   private mediaPlayerService = inject(MediaPlayerService);
+  private repostService = inject(RepostService);
+  private snackBar = inject(MatSnackBar);
+  protected app = inject(ApplicationService);
 
   // UI State Signals
   activeSection = signal<'discover' | 'following' | 'media'>('discover');
@@ -1335,5 +1341,14 @@ export class FeedsComponent implements OnInit, OnDestroy {
       };
       this.mediaPlayerService.enque(mediaItem);
     });
+  }
+
+  async repostNote(event: Event): Promise<void> {
+    const published = await this.repostService.repostNote(event);
+    if (published) {
+      this.snackBar.open('Note reposted successfully!', 'Dismiss', {
+        duration: 3000,
+      });
+    }
   }
 }

--- a/src/app/services/account-relay.service.ts
+++ b/src/app/services/account-relay.service.ts
@@ -956,7 +956,7 @@ export class AccountRelayService {
     }
   }
 
-  publish(event: Event) {
+  publish(event: Event): Promise<string>[] | undefined {
     this.logger.debug('Publishing event:', event);
 
     if (!this.pool) {

--- a/src/app/services/repost.service.ts
+++ b/src/app/services/repost.service.ts
@@ -1,0 +1,43 @@
+import { inject, Injectable } from '@angular/core';
+import { AccountStateService } from './account-state.service';
+import { UnsignedEvent, kinds, Event } from 'nostr-tools';
+import { AccountRelayService } from './account-relay.service';
+import { NostrService } from './nostr.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class RepostService {
+  private accountState = inject(AccountStateService);
+  private nostrService = inject(NostrService);
+  private accountRelayService = inject(AccountRelayService);
+
+  async repostNote(event: Event): Promise<boolean> {
+    // Create the event
+    const unsignedEvent: UnsignedEvent = {
+      kind: kinds.Repost,
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [
+        ['e', event.id],
+        ['p', event.pubkey],
+      ],
+      content: JSON.stringify(event),
+      pubkey: this.accountState.pubkey(),
+    };
+
+    return this.signAndPublish(unsignedEvent);
+  }
+
+  private async signAndPublish(event: UnsignedEvent): Promise<boolean> {
+    const signedEvent = await this.nostrService.signEvent(event);
+
+    const publishPromises = this.accountRelayService.publish(signedEvent);
+
+    if (publishPromises) {
+      await Promise.allSettled(publishPromises);
+      return true;
+    } else {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
Logic is kept in a RepostService so it can be reused across the app (currently in Feeds and Event pages)

Closes #93 