### PR TITLE
feat: show reposts in profile

### DIFF
--- a/src/app/components/content/content.component.scss
+++ b/src/app/components/content/content.component.scss
@@ -1,6 +1,6 @@
 .content-container {
   //   margin-bottom: 1rem;
-  margin: 1rem 1rem 1rem 1rem;
+  margin: 1rem 0rem;
   line-height: 1.6;
   word-break: break-word;
   min-height: 20px; // Ensure there's at least some space to detect visibility

--- a/src/app/components/event/event.component.html
+++ b/src/app/components/event/event.component.html
@@ -1,77 +1,66 @@
 @let item = record();
+@let targetItem = repostedRecord() || item;
 
-@if (item) {
-  <app-user-profile [pubkey]="item.event.pubkey">
-    <a
-      class="date-link"
-      [matTooltip]="item.event.created_at | date: 'medium'"
-      matTooltipPosition="below"
-    >
-      {{ item.event.created_at | ago }}
-    </a>
+@if (targetItem && item) {
+  <mat-card class="note-card" [class.plain]="isPlain()" appearance="outlined">
+    @if (repostedRecord() !== null) {
+      <mat-card-header class="repost-header">
+        <mat-icon>repeat</mat-icon> Reposted
+      </mat-card-header>
+      <mat-card-content>
+        <mat-card appearance="outlined">
+          <app-event-header
+            [event]="repostService.decodeRepost(item.event).event"
+          ></app-event-header>
+          <mat-card-content>
+            <app-content
+              [content]="repostService.decodeRepost(item.event).data"
+            ></app-content>
+          </mat-card-content>
+        </mat-card>
+      </mat-card-content>
+    } @else {
+      <app-event-header [event]="item.event"></app-event-header>
+      <mat-card-content>
+        <app-content [content]="item.data"></app-content>
+      </mat-card-content>
+    }
+    <mat-card-actions class="note-footer">
+      <app-reply-button [event]="targetItem.event"></app-reply-button>
 
-    <button
-      mat-icon-button
-      [matMenuTriggerFor]="menu"
-      aria-label="More options"
-    >
-      <mat-icon>more_vert</mat-icon>
-    </button>
-    <mat-menu #menu="matMenu">
-      <button
-        mat-menu-item
-        (click)="layout.copyToClipboard(layout.getCurrentUrl(), 'text')"
-      >
-        <mat-icon>link</mat-icon>
-        Copy Note Link
+      @if (app.enabledFeature('beta')) {
+        @if (repostsCount() > 0) {
+          <button
+            mat-button
+            (click)="repostService.repostNote(targetItem.event)"
+          >
+            <mat-icon>repeat</mat-icon>
+            {{ repostsCount() }}
+          </button>
+        } @else {
+          <button
+            mat-icon-button
+            (class)="
+              repostService.isReposted(targetItem.event.id) ? 'active' : ''
+            "
+            (click)="repostService.repostNote(targetItem.event)"
+          >
+            <mat-icon>repeat</mat-icon>
+          </button>
+        }
+      }
+
+      <button mat-icon-button class="note-footer-right">
+        <mat-icon
+          [matTooltip]="bookmark.getBookmarkTooltip(targetItem.event.id)"
+          matTooltipPosition="below"
+          (click)="bookmark.toggleBookmark(targetItem.event.id)"
+        >
+          {{ bookmark.getBookmarkIcon(targetItem.event.id) }}
+        </mat-icon>
       </button>
-      <button
-        mat-menu-item
-        (click)="
-          layout.copyToClipboard(item.event.id, 'nevent', item.event.pubkey)
-        "
-      >
-        <mat-icon>content_copy</mat-icon>
-        Copy Note ID (nevent)
-      </button>
-      <button
-        mat-menu-item
-        (click)="layout.copyToClipboard(item.event.id, 'hex')"
-      >
-        <mat-icon>content_copy</mat-icon>
-        Copy Note ID (hex)
-      </button>
-      <button mat-menu-item (click)="layout.shareEvent(item.event)">
-        <mat-icon>share</mat-icon>
-        Share Event
-      </button>
-      <mat-divider></mat-divider>
-      <button mat-menu-item (click)="layout.copyToClipboard(item.data, 'text')">
-        <mat-icon>content_copy</mat-icon>
-        Copy Note Text
-      </button>
-      <button
-        mat-menu-item
-        (click)="layout.copyToClipboard(item.event, 'json')"
-      >
-        <mat-icon>content_copy</mat-icon>
-        Copy Note Data
-      </button>
-      <mat-divider></mat-divider>
-      <button mat-menu-item (click)="publishEvent()">
-        <mat-icon>publish</mat-icon>
-        Publish Event
-      </button>
-      <!-- <button mat-menu-item>
-      <mat-icon>warning</mat-icon>
-      Report Content
-    </button> -->
-    </mat-menu>
-  </app-user-profile>
-  <div class="event-content" (click)="openEvent()">
-    <!-- {{ item.event.pubkey}}<br> -->
-    <app-content [content]="item.data"></app-content>
-  </div>
+    </mat-card-actions>
+  </mat-card>
 } @else {
   <div class="event-content">
     <p>Event not found</p>

--- a/src/app/components/event/event.component.html
+++ b/src/app/components/event/event.component.html
@@ -40,9 +40,9 @@
         } @else {
           <button
             mat-icon-button
-            (class)="
-              repostService.isReposted(targetItem.event.id) ? 'active' : ''
-            "
+            [ngClass]="{
+              active: repostService.isReposted(targetItem.event.id),
+            }"
             (click)="repostService.repostNote(targetItem.event)"
           >
             <mat-icon>repeat</mat-icon>

--- a/src/app/components/event/event.component.scss
+++ b/src/app/components/event/event.component.scss
@@ -1,3 +1,32 @@
 .event-content {
   cursor: pointer;
 }
+
+.note-card {
+  &.plain {
+    border-radius: 0;
+    border: none;
+  }
+}
+
+.note-footer {
+  display: flex;
+}
+
+.note-footer-right {
+  margin-left: auto;
+}
+
+button.active {
+  color: rgb(52, 152, 219);
+}
+
+.repost-header {
+  font-style: italic;
+  opacity: 0.7;
+
+  mat-icon {
+    font-size: 18px;
+    line-height: 21px;
+  }
+}

--- a/src/app/components/event/event.component.ts
+++ b/src/app/components/event/event.component.ts
@@ -1,37 +1,41 @@
-import { Component, inject, input, signal, effect } from '@angular/core';
-import { DataService } from '../../services/data.service';
-import { Event } from 'nostr-tools';
-import { NostrRecord } from '../../interfaces';
-import { UserProfileComponent } from '../user-profile/user-profile.component';
-import { LayoutService } from '../../services/layout.service';
-import { ContentComponent } from '../content/content.component';
-import { AgoPipe } from '../../pipes/ago.pipe';
-import { MatTooltipModule } from '@angular/material/tooltip';
-import { DatePipe } from '@angular/common';
-import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
-import { MatMenuModule } from '@angular/material/menu';
-import { AccountRelayService } from '../../services/account-relay.service';
-import { MatDividerModule } from '@angular/material/divider';
-import { MatDialog } from '@angular/material/dialog';
 import {
-  PublishDialogComponent,
-  PublishDialogData,
-} from './publish-dialog/publish-dialog.component';
+  Component,
+  computed,
+  effect,
+  inject,
+  input,
+  signal,
+} from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatDialog } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { Event, kinds } from 'nostr-tools';
+import { NostrRecord } from '../../interfaces';
+import { AccountRelayService } from '../../services/account-relay.service';
 import { ApplicationService } from '../../services/application.service';
+import { BookmarkService } from '../../services/bookmark.service';
+import { DataService } from '../../services/data.service';
+import { LayoutService } from '../../services/layout.service';
+import { RepostService } from '../../services/repost.service';
+import { ContentComponent } from '../content/content.component';
+import { ReplyButtonComponent } from './reply-button/reply-button.component';
+import { EventHeaderComponent } from './header/header.component';
+
+type EventCardAppearance = 'card' | 'plain';
 
 @Component({
   selector: 'app-event',
   imports: [
-    UserProfileComponent,
+    ReplyButtonComponent,
+    EventHeaderComponent,
     ContentComponent,
-    AgoPipe,
     MatTooltipModule,
-    DatePipe,
-    MatDividerModule,
+    MatCardModule,
     MatButtonModule,
     MatIconModule,
-    MatMenuModule,
   ],
   templateUrl: './event.component.html',
   styleUrl: './event.component.scss',
@@ -40,12 +44,24 @@ export class EventComponent {
   id = input<string | null | undefined>();
   type = input<'e' | 'a' | 'r' | 't'>('e');
   event = input<Event | null | undefined>(null);
+  appearance = input<EventCardAppearance>('plain');
+  repostsCount = input<number>(0);
+  isPlain = computed<boolean>(() => this.appearance() === 'plain');
+
   data = inject(DataService);
   record = signal<NostrRecord | null>(null);
+  bookmark = inject(BookmarkService);
+  repostService = inject(RepostService);
   layout = inject(LayoutService);
   accountRelayService = inject(AccountRelayService);
   dialog = inject(MatDialog);
+  snackBar = inject(MatSnackBar);
   app = inject(ApplicationService);
+  repostedRecord = computed<NostrRecord | null>(() => {
+    const event = this.event();
+    if (!event || event.kind !== kinds.Repost) return null;
+    return this.repostService.decodeRepost(event);
+  });
 
   constructor() {
     effect(() => {
@@ -76,39 +92,6 @@ export class EventComponent {
           }
         }
       }
-    });
-  }
-
-  openEvent(): void {
-    const id = this.id();
-    const type = this.type();
-
-    if (!id) {
-      return;
-    }
-
-    if (type === 'r') {
-      window.open(id, '_blank');
-    } else if (type === 'e') {
-      this.layout.openEvent(id, this.record()?.event);
-    } else if (type === 'a') {
-      this.layout.openArticle(id, this.record()?.event);
-    }
-  }
-  async publishEvent() {
-    const event = this.record()?.event;
-    if (!event) {
-      return;
-    }
-
-    const dialogData: PublishDialogData = {
-      event: event,
-    };
-
-    this.dialog.open(PublishDialogComponent, {
-      data: dialogData,
-      width: '600px',
-      disableClose: false,
     });
   }
 }

--- a/src/app/components/event/event.component.ts
+++ b/src/app/components/event/event.component.ts
@@ -23,12 +23,14 @@ import { RepostService } from '../../services/repost.service';
 import { ContentComponent } from '../content/content.component';
 import { ReplyButtonComponent } from './reply-button/reply-button.component';
 import { EventHeaderComponent } from './header/header.component';
+import { CommonModule } from '@angular/common';
 
 type EventCardAppearance = 'card' | 'plain';
 
 @Component({
   selector: 'app-event',
   imports: [
+    CommonModule,
     ReplyButtonComponent,
     EventHeaderComponent,
     ContentComponent,

--- a/src/app/components/event/header/header.component.html
+++ b/src/app/components/event/header/header.component.html
@@ -1,0 +1,65 @@
+<mat-card-header>
+  <app-user-profile [pubkey]="event().pubkey">
+    <a
+      class="date-link"
+      [matTooltip]="event().created_at * 1000 | date: 'medium'"
+      matTooltipPosition="below"
+      (click)="layout.openEvent(event())"
+    >
+      {{ event().created_at | ago }}
+    </a>
+
+    <button
+      mat-icon-button
+      [matMenuTriggerFor]="menu"
+      aria-label="More options"
+    >
+      <mat-icon>more_vert</mat-icon>
+    </button>
+    <mat-menu #menu="matMenu">
+      <button
+        mat-menu-item
+        (click)="layout.copyToClipboard(layout.getCurrentUrl(), 'text')"
+      >
+        <mat-icon>link</mat-icon>
+        Copy Note Link
+      </button>
+      <button
+        mat-menu-item
+        (click)="layout.copyToClipboard(event().id, 'nevent', event().pubkey)"
+      >
+        <mat-icon>content_copy</mat-icon>
+        Copy Note ID (nevent)
+      </button>
+      <button mat-menu-item (click)="layout.copyToClipboard(event().id, 'hex')">
+        <mat-icon>content_copy</mat-icon>
+        Copy Note ID (hex)
+      </button>
+      <button mat-menu-item (click)="layout.shareEvent(event())">
+        <mat-icon>share</mat-icon>
+        Share Event
+      </button>
+      <mat-divider></mat-divider>
+      <button
+        mat-menu-item
+        (click)="layout.copyToClipboard(record()?.data, 'text')"
+      >
+        <mat-icon>content_copy</mat-icon>
+        Copy Note Text
+      </button>
+      <button mat-menu-item (click)="layout.copyToClipboard(event(), 'json')">
+        <mat-icon>content_copy</mat-icon>
+        Copy Note Data
+      </button>
+      <mat-divider></mat-divider>
+      <button mat-menu-item (click)="publishEvent()">
+        <mat-icon>publish</mat-icon>
+        Publish Event
+      </button>
+      <!-- <button mat-menu-item>
+        <mat-icon>warning</mat-icon>
+        Report Content
+      </button> -->
+    </mat-menu>
+  </app-user-profile>
+</mat-card-header>

--- a/src/app/components/event/header/header.component.scss
+++ b/src/app/components/event/header/header.component.scss
@@ -1,0 +1,7 @@
+mat-card-header {
+  padding-right: 8px;
+}
+
+.date-link {
+  cursor: pointer;
+}

--- a/src/app/components/event/header/header.component.ts
+++ b/src/app/components/event/header/header.component.ts
@@ -1,0 +1,76 @@
+import { Component, effect, inject, input, signal } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { LayoutService } from '../../../services/layout.service';
+import {
+  PublishDialogComponent,
+  PublishDialogData,
+} from '../publish-dialog/publish-dialog.component';
+import { Event } from 'nostr-tools';
+import { MatDialog } from '@angular/material/dialog';
+import { MatDividerModule } from '@angular/material/divider';
+import { NostrRecord } from '../../../interfaces';
+import { DataService } from '../../../services/data.service';
+import { MatMenuModule } from '@angular/material/menu';
+import { AgoPipe } from '../../../pipes/ago.pipe';
+import { DatePipe } from '@angular/common';
+import { UserProfileComponent } from '../../user-profile/user-profile.component';
+import { MatCardModule } from '@angular/material/card';
+
+@Component({
+  selector: 'app-event-header',
+  standalone: true,
+  imports: [
+    MatCardModule,
+    MatIconModule,
+    MatButtonModule,
+    MatTooltipModule,
+    MatDividerModule,
+    MatMenuModule,
+    UserProfileComponent,
+    AgoPipe,
+    DatePipe,
+  ],
+  templateUrl: './header.component.html',
+  styleUrls: ['./header.component.scss'],
+})
+export class EventHeaderComponent {
+  readonly layout = inject(LayoutService);
+  dialog = inject(MatDialog);
+  data = inject(DataService);
+
+  event = input.required<Event>();
+
+  record = signal<NostrRecord | null>(null);
+
+  constructor() {
+    effect(() => {
+      const event = this.event();
+
+      if (!event) {
+        return;
+      }
+
+      const record = this.data.toRecord(event);
+      this.record.set(record);
+    });
+  }
+
+  async publishEvent() {
+    const event = this.event();
+    if (!event) {
+      return;
+    }
+
+    const dialogData: PublishDialogData = {
+      event,
+    };
+
+    this.dialog.open(PublishDialogComponent, {
+      data: dialogData,
+      width: '600px',
+      disableClose: false,
+    });
+  }
+}

--- a/src/app/components/event/reply-button/reply-button.component.html
+++ b/src/app/components/event/reply-button/reply-button.component.html
@@ -1,0 +1,7 @@
+<button mat-icon-button (click)="onClick()">
+  @if (isLongFormArticle()) {
+    <mat-icon matTooltip="Comment" matTooltipPosition="below">comment</mat-icon>
+  } @else {
+    <mat-icon matTooltip="Reply" matTooltipPosition="below">reply</mat-icon>
+  }
+</button>

--- a/src/app/components/event/reply-button/reply-button.component.scss
+++ b/src/app/components/event/reply-button/reply-button.component.scss
@@ -1,0 +1,2 @@
+// Component-specific styles for reply-button
+// Global styles should be used for common styling patterns

--- a/src/app/components/event/reply-button/reply-button.component.ts
+++ b/src/app/components/event/reply-button/reply-button.component.ts
@@ -22,7 +22,6 @@ export class ReplyButtonComponent {
   );
 
   onClick(): void {
-    console.log('!');
     this.layout.commentNote(this.event().id);
   }
 }

--- a/src/app/components/event/reply-button/reply-button.component.ts
+++ b/src/app/components/event/reply-button/reply-button.component.ts
@@ -1,0 +1,28 @@
+import { Component, computed, inject, input } from '@angular/core';
+import { Event, kinds } from 'nostr-tools';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { LayoutService } from '../../../services/layout.service';
+
+@Component({
+  selector: 'app-reply-button',
+  standalone: true,
+  imports: [MatIconModule, MatButtonModule, MatTooltipModule],
+  templateUrl: './reply-button.component.html',
+  styleUrls: ['./reply-button.component.scss'],
+})
+export class ReplyButtonComponent {
+  private readonly layout = inject(LayoutService);
+
+  event = input.required<Event>();
+
+  isLongFormArticle = computed(
+    () => this.event().kind === kinds.LongFormArticle
+  );
+
+  onClick(): void {
+    console.log('!');
+    this.layout.commentNote(this.event().id);
+  }
+}

--- a/src/app/components/user-profile/user-profile.component.html
+++ b/src/app/components/user-profile/user-profile.component.html
@@ -4,151 +4,158 @@
 
 <div [ngClass]="['user-profile', view()]">
   @if (info()) {
-  <div class="user-info-status" [matTooltip]="getInfoTooltip()" [matTooltipClass]="'user-profile-tooltip'">
-    @if (this.info()!['hasRelayList']) {
-    <mat-icon class="user-info-icon" [class]="getInfoClass()">info</mat-icon>
-    } @else {
-    <mat-icon class="user-info-icon" [class]="getInfoClass()">warning</mat-icon>
-    }
-  </div>
+    <div
+      class="user-info-status"
+      [matTooltip]="getInfoTooltip()"
+      [matTooltipClass]="'user-profile-tooltip'"
+    >
+      @if (this.info()!['hasRelayList']) {
+        <mat-icon class="user-info-icon" [class]="getInfoClass()"
+          >info</mat-icon
+        >
+      } @else {
+        <mat-icon class="user-info-icon" [class]="getInfoClass()"
+          >warning</mat-icon
+        >
+      }
+    </div>
   }
 
   <div class="user-profile-container">
     <!-- Banner section for grid view -->
     @if (view() === 'grid' && profile()?.data?.banner) {
-    <div class="user-profile-banner">
-      <img [src]="profile().data.banner" onerror="this.onerror=null; this.src='images/banner-failure.png';"
-        alt="User Banner" class="user-banner" />
-    </div>
+      <div class="user-profile-banner">
+        <img
+          [src]="profile().data.banner"
+          onerror="this.onerror=null; this.src='images/banner-failure.png';"
+          alt="User Banner"
+          class="user-banner"
+        />
+      </div>
     }
 
     <!-- Avatar section - single image element -->
-    <a [routerLink]="['/p', publicKey]" class="user-profile-avatar" [matTooltip]="
+    <a
+      [routerLink]="['/p', publicKey]"
+      class="user-profile-avatar"
+      [matTooltip]="
         view() === 'large' || view() === 'medium' || view() === 'small'
           ? getTooltipContent()
           : ''
-      " [matTooltipClass]="'user-profile-tooltip'" matTooltipPosition="above" (touchstart)="handleTouchStart($event)"
-      (touchmove)="handleTouchMove($event)" (touchend)="handleTouchEnd($event)">
+      "
+      [matTooltipClass]="'user-profile-tooltip'"
+      matTooltipPosition="above"
+      (touchstart)="handleTouchStart($event)"
+      (touchmove)="handleTouchMove($event)"
+      (touchend)="handleTouchEnd($event)"
+    >
       <!-- <a [routerLink]="['/p', pubkey()]" class="user-profile-avatar"
       [matTooltip]="view() === 'large' || view() === 'medium' || view() === 'small' ? getTooltipContent() : ''"
       [matTooltipClass]="'user-profile-tooltip'" matTooltipPosition="above" (touchstart)="handleTouchEvent($event)"
       (touchmove)="handleTouchEvent($event)" (touchend)="handleTouchEvent($event)"> -->
 
       @if (isLoading()) {
-      <mat-spinner [diameter]="getSpinnerSize()" color="primary"></mat-spinner>
+        <mat-spinner
+          [diameter]="getSpinnerSize()"
+          color="primary"
+        ></mat-spinner>
       } @else if (profile()?.data?.picture && !imageLoadError()) {
-      @if (settingsService.settings().imageCacheEnabled) {
-      <img [src]="
+        @if (settingsService.settings().imageCacheEnabled) {
+          <img
+            [src]="
               'https://proxy.eu.nostria.app/api/ImageOptimizeProxy?w=250&h=250&url=' +
               profile().data.picture
-            " (error)="onImageLoadError()" alt="User Avatar" class="user-avatar" />
+            "
+            (error)="onImageLoadError()"
+            alt="User Avatar"
+            class="user-avatar"
+          />
+        } @else {
+          <img
+            [src]="profile().data.picture"
+            (error)="onImageLoadError()"
+            alt="User Avatar"
+            class="user-avatar"
+          />
+        }
       } @else {
-      <img [src]="profile().data.picture" (error)="onImageLoadError()" alt="User Avatar" class="user-avatar" />
-      }
-      } @else {
-      <mat-icon [ngClass]="[
+        <mat-icon
+          [ngClass]="[
             'default-user-avatar',
             isProfileNotFound() ? 'not-found-avatar' : '',
             imageLoadError() ? 'error-avatar' : '',
-          ]" [style.font-size]="getDefaultAvatarSize()" [style.height]="getDefaultAvatarSize()"
-        [style.width]="getDefaultAvatarSize()">
-        {{ isProfileNotFound() ? 'no_accounts' : 'account_circle' }}
-      </mat-icon>
+          ]"
+          [style.font-size]="getDefaultAvatarSize()"
+          [style.height]="getDefaultAvatarSize()"
+          [style.width]="getDefaultAvatarSize()"
+        >
+          {{ isProfileNotFound() ? 'no_accounts' : 'account_circle' }}
+        </mat-icon>
       }
     </a>
     <!-- Content section with conditional rendering based on view -->
     @if (
-    view() !== 'large' &&
-    view() !== 'medium' &&
-    view() !== 'small' &&
-    view() !== 'icon'
+      view() !== 'large' &&
+      view() !== 'medium' &&
+      view() !== 'small' &&
+      view() !== 'icon'
     ) {
-    <div class="user-profile-content">
-      <!-- Name section -->
-      <a [routerLink]="['/p', publicKey]" class="user-profile-name">
-        @if (isLoading()) {
-        Loading...
-        } @else if (profile() && !profile().isEmpty && profile().data) {
-        @if (profile().data.display_name) {
-        {{ profile().data.display_name }}
-        } @else if (profile().data.name) {
-        {{ profile().data.name }}
-        } @else {
-        [No name]
+      <div class="user-profile-content">
+        <!-- Name section -->
+        <a [routerLink]="['/p', publicKey]" class="user-profile-name">
+          @if (isLoading()) {
+            Loading...
+          } @else if (profile() && !profile().isEmpty && profile().data) {
+            @if (profile().data.display_name) {
+              {{ profile().data.display_name }}
+            } @else if (profile().data.name) {
+              {{ profile().data.name }}
+            } @else {
+              [No name]
+            }
+          } @else {
+            [Not found]
+          }
+        </a>
+
+        <!-- NPUB section - only shown in appropriate views -->
+        @if (view() === 'list' || view() === 'details') {
+          <div class="user-profile-npub">{{ aliasOrNpub() }}</div>
         }
-        } @else {
-        [Not found]
+
+        <!-- About section - only shown in details view -->
+        @if (
+          view() === 'details' &&
+          profile() &&
+          profile().data &&
+          profile().data.about
+        ) {
+          <div class="user-profile-about">{{ profile().data.about }}</div>
         }
-      </a>
 
-      <!-- NPUB section - only shown in appropriate views -->
-      @if (view() === 'list' || view() === 'details') {
-      <div class="user-profile-npub">{{ aliasOrNpub() }}</div>
-      }
-
-      <!-- About section - only shown in details view -->
-      @if (
-      view() === 'details' &&
-      profile() &&
-      profile().data &&
-      profile().data.about
-      ) {
-      <div class="user-profile-about">{{ profile().data.about }}</div>
-      }
-
-      @if (view() === 'details' && profile() && profile().data) {
-      @if (profile().data.nip05) {
-      <div class="user-profile-details">
-        NIP-05: {{ profile().data.nip05 }}
+        @if (view() === 'details' && profile() && profile().data) {
+          @if (profile().data.nip05) {
+            <div class="user-profile-details">
+              NIP-05: {{ profile().data.nip05 }}
+            </div>
+          }
+          @if (profile().data.lud16) {
+            <div class="user-profile-details">
+              LUD16: {{ profile().data.lud16 }}
+            </div>
+          }
+          @if (profile().data.website) {
+            <div class="user-profile-details">
+              Website: {{ profile().data.website }}
+            </div>
+          }
+        }
       </div>
-      }
-      @if (profile().data.lud16) {
-      <div class="user-profile-details">
-        LUD16: {{ profile().data.lud16 }}
-      </div>
-      }
-      @if (profile().data.website) {
-      <div class="user-profile-details">
-        Website: {{ profile().data.website }}
-      </div>
-      }
-      }
-    </div>
     }
 
     <!-- Named content projection for additional controls (like more options button) -->
     <div class="user-profile-custom-content">
       <ng-content></ng-content>
     </div>
-
-    @if (view() === 'thread') {
-    <div>
-      <button mat-icon-button [matMenuTriggerFor]="menu">
-        <mat-icon>more_vert</mat-icon>
-      </button>
-
-      <mat-menu #copyMenu="matMenu">
-        <button mat-menu-item (click)="layout.copyToClipboard(event()?.pubkey, 'note')">
-          <span>Event ID (note)</span>
-        </button>
-        <button mat-menu-item (click)="layout.copyToClipboard(event()?.pubkey, 'hex')">
-          <span>Event ID (hex)</span>
-        </button>
-        <button mat-menu-item (click)="layout.copyToClipboard(event, 'nevent')">
-          <span>Event ID (nevent)</span>
-        </button>
-        <button mat-menu-item (click)="copyEventData()">
-          <span>Event Data</span>
-        </button>
-      </mat-menu>
-
-      <mat-menu #menu="matMenu">
-        <button mat-menu-item [matMenuTriggerFor]="copyMenu">
-          <mat-icon>content_copy</mat-icon>
-          <span>Copy</span>
-        </button>
-      </mat-menu>
-    </div>
-    }
   </div>
 </div>

--- a/src/app/components/user-profile/user-profile.component.scss
+++ b/src/app/components/user-profile/user-profile.component.scss
@@ -1,6 +1,6 @@
 :host {
   display: block;
-  width: auto; // Changed from 100% to auto to allow fixed widths of parents
+  width: 100%;
 }
 
 .user-profile {
@@ -46,8 +46,10 @@
     overflow: hidden;
     flex-shrink: 0;
     border: 2px solid;
-    border-color: var(--mat-button-text-label-text-color,
-        var(--mat-sys-primary));
+    border-color: var(
+      --mat-button-text-label-text-color,
+      var(--mat-sys-primary)
+    );
     background-color: var(--mat-card-subtle-surface-color, #e0e0e0);
     // Allow touch scrolling to pass through
     touch-action: manipulation;
@@ -75,14 +77,12 @@
       font-size: 100%;
 
       &.not-found-avatar {
-        color: var(--mat-warn-color,
-            #f44336);
+        color: var(--mat-warn-color, #f44336);
         /* Use Material's warning color for not found or error profiles */
       }
 
       &.error-avatar {
-        color: var(--mat-warn-color,
-            #be09af);
+        color: var(--mat-warn-color, #be09af);
         /* Use Material's warning color for not found or error profiles */
       }
     }

--- a/src/app/pages/bookmarks/bookmarks.component.ts
+++ b/src/app/pages/bookmarks/bookmarks.component.ts
@@ -288,10 +288,10 @@ export class BookmarksComponent {
   openBookmark(bookmark: Bookmark): void {
     if (bookmark.type === 'r') {
       window.open(bookmark.url, '_blank');
+    } else if (bookmark.type === 'a') {
+      this.layout.openArticle(bookmark.id);
     } else {
-      // For events and articles, navigate within the app
-      // this.router.navigate([bookmark.url]);
-      this.layout.openEvent(bookmark.id);
+      this.layout.openGenericEvent(bookmark.id);
     }
     this.logger.debug('Opening bookmark:', bookmark.url);
   }

--- a/src/app/pages/event/event.component.html
+++ b/src/app/pages/event/event.component.html
@@ -1,6 +1,10 @@
 <h1></h1>
 
-<app-event [event]="event()"></app-event>
+<app-event
+  [event]="event()"
+  appearance="plain"
+  [repostsCount]="reposts().length"
+></app-event>
 
 <div class="reactions">
   @for (reaction of reactions(); track reaction.emoji) {
@@ -10,20 +14,6 @@
     </div>
   }
 </div>
-
-@if (app.enabledFeature('beta')) {
-  @if (reposts()) {
-    <button matButton (click)="repostNote()">
-      <mat-icon>repeat</mat-icon>
-      <span>{{ reposts().length }}</span>
-    </button>
-  }
-}
-
-<button matButton (click)="layout.commentNote(event()?.id)">
-  <mat-icon>comment</mat-icon>
-  <span>Comment</span>
-</button>
 
 <!-- <app-note-editor-dialog></app-note-editor-dialog> -->
 

--- a/src/app/pages/event/event.component.ts
+++ b/src/app/pages/event/event.component.ts
@@ -24,8 +24,6 @@ import { MatButtonModule } from '@angular/material/button';
 import { ApplicationService } from '../../services/application.service';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { EVENT_STATE_KEY, EventData } from '../../data-resolver';
-import { RepostService } from '../../services/repost.service';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { NoteEditorDialogComponent } from '../../components/note-editor-dialog/note-editor-dialog.component';
 
 /** Description of the EventPageComponent
@@ -84,8 +82,6 @@ export class EventPageComponent implements OnInit, OnDestroy {
   replies = signal<Event[]>([]);
   threadedReplies = signal<ThreadedEvent[]>([]);
   transferState = inject(TransferState);
-  private repostService = inject(RepostService);
-  private snackBar = inject(MatSnackBar);
 
   item!: EventData;
 
@@ -477,16 +473,5 @@ export class EventPageComponent implements OnInit, OnDestroy {
     // Navigate to the specific event to view deeper replies
     const encoded = nip19.neventEncode({ id: eventId });
     this.router.navigate(['/e', encoded]);
-  }
-
-  async repostNote(): Promise<void> {
-    const event = this.event();
-    if (!event) return;
-    const published = await this.repostService.repostNote(event);
-    if (published) {
-      this.snackBar.open('Note reposted successfully!', 'Dismiss', {
-        duration: 3000,
-      });
-    }
   }
 }

--- a/src/app/pages/feeds/feeds.component.html
+++ b/src/app/pages/feeds/feeds.component.html
@@ -651,7 +651,7 @@
                             @if (app.enabledFeature('beta')) {
                               <button
                                 mat-icon-button
-                                (click)="repostNote(event)"
+                                (click)="repostService.repostNote(event)"
                               >
                                 <mat-icon>repeat</mat-icon>
                               </button>

--- a/src/app/pages/feeds/feeds.component.ts
+++ b/src/app/pages/feeds/feeds.component.ts
@@ -55,7 +55,6 @@ import { MatDividerModule } from '@angular/material/divider';
 import { ContentComponent } from '../../components/content/content.component';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ApplicationService } from '../../services/application.service';
-import { RepostService } from '../../services/repost.service';
 import { Link } from '../../components/link/link';
 import { Introduction } from '../../components/introduction/introduction';
 import {
@@ -65,6 +64,7 @@ import {
 } from '../../components/followset/followset.component';
 import { AccountStateService } from '../../services/account-state.service';
 import { Followset } from '../../services/followset';
+import { RepostService } from '../../services/repost.service';
 
 interface NavLink {
   id: string;
@@ -122,7 +122,7 @@ export class FeedsComponent implements OnInit, OnDestroy {
   private url = inject(UrlUpdateService);
   private cdr = inject(ChangeDetectorRef);
   private mediaPlayerService = inject(MediaPlayerService);
-  private repostService = inject(RepostService);
+  protected repostService = inject(RepostService);
   private snackBar = inject(MatSnackBar);
   protected app = inject(ApplicationService);
   private accountState = inject(AccountStateService);
@@ -1513,14 +1513,5 @@ export class FeedsComponent implements OnInit, OnDestroy {
       };
       this.mediaPlayerService.enque(mediaItem);
     });
-  }
-
-  async repostNote(event: Event): Promise<void> {
-    const published = await this.repostService.repostNote(event);
-    if (published) {
-      this.snackBar.open('Note reposted successfully!', 'Dismiss', {
-        duration: 3000,
-      });
-    }
   }
 }

--- a/src/app/pages/profile/profile-notes/profile-notes.component.html
+++ b/src/app/pages/profile/profile-notes/profile-notes.component.html
@@ -16,40 +16,7 @@
       } @else {
         <div class="notes-list">
           @for (note of profileState.sortedNotes(); track note.event.id) {
-            <mat-card class="note-card" appearance="outlined">
-              <app-user-profile
-                class="user-profile-thread"
-                view="thread"
-                [pubkey]="profileState.currentProfilePubkey()"
-              >
-                <a
-                  class="date-link"
-                  (click)="layout.openEvent(note.event.id, note.event)"
-                  [matTooltip]="note.event.created_at * 1000 | date: 'medium'"
-                  matTooltipPosition="below"
-                >
-                  {{ note.event.created_at | ago }}
-                </a>
-              </app-user-profile>
-              <app-content [content]="note.data"></app-content>
-              <!-- <mat-card-content>{{note.content}}</mat-card-content> -->
-              <mat-card-footer class="note-footer">
-                <button mat-icon-button>
-                  <mat-icon matTooltip="Reply" matTooltipPosition="below"
-                    >reply</mat-icon
-                  >
-                </button>
-                <button mat-icon-button class="note-footer-right">
-                  <mat-icon
-                    [matTooltip]="bookmark.getBookmarkTooltip(note.event.id)"
-                    matTooltipPosition="below"
-                    (click)="bookmark.toggleBookmark(note.event.id)"
-                  >
-                    {{ bookmark.getBookmarkIcon(note.event.id) }}
-                  </mat-icon>
-                </button>
-              </mat-card-footer>
-            </mat-card>
+            <app-event [event]="note.event" appearance="card"></app-event>
           }
 
           <!-- Loading more indicator -->

--- a/src/app/pages/profile/profile-notes/profile-notes.component.ts
+++ b/src/app/pages/profile/profile-notes/profile-notes.component.ts
@@ -5,35 +5,29 @@ import { RouterModule } from '@angular/router';
 import { LoggerService } from '../../../services/logger.service';
 import { LoadingOverlayComponent } from '../../../components/loading-overlay/loading-overlay.component';
 import { ProfileStateService } from '../../../services/profile-state.service';
-import { MatCardModule } from '@angular/material/card';
-import { UserProfileComponent } from '../../../components/user-profile/user-profile.component';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { BookmarkService } from '../../../services/bookmark.service';
-import { AgoPipe } from '../../../pipes/ago.pipe';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { FormsModule } from '@angular/forms';
-import { ContentComponent } from '../../../components/content/content.component';
 import { LayoutService } from '../../../services/layout.service';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { EventComponent } from '../../../components/event/event.component';
 
 @Component({
   selector: 'app-profile-notes',
   standalone: true,
   imports: [
     CommonModule,
+    EventComponent,
     MatIconModule,
     LoadingOverlayComponent,
-    MatCardModule,
-    UserProfileComponent,
     RouterModule,
     MatTooltipModule,
-    AgoPipe,
     MatIconModule,
     MatButtonModule,
     MatSlideToggleModule,
     FormsModule,
-    ContentComponent,
     MatProgressSpinnerModule,
   ],
   templateUrl: './profile-notes.component.html',

--- a/src/app/services/layout.service.ts
+++ b/src/app/services/layout.service.ts
@@ -19,7 +19,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { BreakpointObserver } from '@angular/cdk/layout';
 import { MediaPreviewDialogComponent } from '../components/media-preview-dialog/media-preview.component';
-import { Event, nip19 } from 'nostr-tools';
+import { Event, kinds, nip19 } from 'nostr-tools';
 import {
   AddressPointer,
   EventPointer,
@@ -664,7 +664,7 @@ export class LayoutService implements OnDestroy {
       this.toggleSearch();
       try {
         const decoded = nip19.decode(value).data as EventPointer;
-        this.openEvent(value);
+        this.openGenericEvent(value);
       } catch (error) {
         console.warn('Failed to decode nevent:', value, error);
         this.toast('Invalid event format', 3000, 'error-snackbar');
@@ -712,7 +712,15 @@ export class LayoutService implements OnDestroy {
     this.router.navigate(['/p', pubkey]);
   }
 
-  openEvent(naddr: string, event?: Event): void {
+  openEvent(event: Event): void {
+    if (event.kind === kinds.LongFormArticle) {
+      this.openArticle(event.id, event);
+    } else {
+      this.openGenericEvent(event.id, event);
+    }
+  }
+
+  openGenericEvent(naddr: string, event?: Event): void {
     this.router.navigate(['/e', naddr], { state: { event } });
   }
 

--- a/src/app/services/repost.service.ts
+++ b/src/app/services/repost.service.ts
@@ -53,28 +53,6 @@ export class RepostService {
     };
   }
 
-  // async deleteRepost(event: Event): Promise<boolean> {
-  //   // Create the event
-  //   const unsignedEvent: UnsignedEvent = {
-  //     kind: kinds.EventDeletion,
-  //     created_at: Math.floor(Date.now() / 1000),
-  //     tags: [
-  //       ['e', event.id],
-  //       ['k', String(event.kind)],
-  //     ],
-  //     content: '',
-  //     pubkey: this.accountState.pubkey(),
-  //   };
-
-  //   const published = await this.signAndPublish(unsignedEvent);
-  //   if (published) {
-  //     this.snackBar.open('Note was requested for delete', 'Dismiss', {
-  //       duration: 3000,
-  //     });
-  //   }
-  //   return published;
-  // }
-
   private async signAndPublish(event: UnsignedEvent): Promise<boolean> {
     const signedEvent = await this.nostrService.signEvent(event);
 

--- a/src/app/services/repost.service.ts
+++ b/src/app/services/repost.service.ts
@@ -1,8 +1,12 @@
 import { inject, Injectable } from '@angular/core';
-import { AccountStateService } from './account-state.service';
-import { UnsignedEvent, kinds, Event } from 'nostr-tools';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Event, kinds, UnsignedEvent } from 'nostr-tools';
 import { AccountRelayService } from './account-relay.service';
+import { AccountStateService } from './account-state.service';
 import { NostrService } from './nostr.service';
+import { ProfileStateService } from './profile-state.service';
+import { UtilitiesService } from './utilities.service';
+import { NostrRecord } from '../interfaces';
 
 @Injectable({
   providedIn: 'root',
@@ -11,6 +15,13 @@ export class RepostService {
   private accountState = inject(AccountStateService);
   private nostrService = inject(NostrService);
   private accountRelayService = inject(AccountRelayService);
+  private snackBar = inject(MatSnackBar);
+  private profileService = inject(ProfileStateService);
+  private utilities = inject(UtilitiesService);
+
+  isReposted(eventId: string): boolean {
+    return this.profileService.reposts().some(r => r.event.id === eventId);
+  }
 
   async repostNote(event: Event): Promise<boolean> {
     // Create the event
@@ -25,8 +36,44 @@ export class RepostService {
       pubkey: this.accountState.pubkey(),
     };
 
-    return this.signAndPublish(unsignedEvent);
+    const published = await this.signAndPublish(unsignedEvent);
+    if (published) {
+      this.snackBar.open('Note reposted successfully!', 'Dismiss', {
+        duration: 3000,
+      });
+    }
+    return published;
   }
+
+  decodeRepost(event: Event): NostrRecord {
+    const repostedEvent = this.utilities.parseContent(event.content);
+    return {
+      event: repostedEvent,
+      data: this.utilities.parseContent(repostedEvent.content),
+    };
+  }
+
+  // async deleteRepost(event: Event): Promise<boolean> {
+  //   // Create the event
+  //   const unsignedEvent: UnsignedEvent = {
+  //     kind: kinds.EventDeletion,
+  //     created_at: Math.floor(Date.now() / 1000),
+  //     tags: [
+  //       ['e', event.id],
+  //       ['k', String(event.kind)],
+  //     ],
+  //     content: '',
+  //     pubkey: this.accountState.pubkey(),
+  //   };
+
+  //   const published = await this.signAndPublish(unsignedEvent);
+  //   if (published) {
+  //     this.snackBar.open('Note was requested for delete', 'Dismiss', {
+  //       duration: 3000,
+  //     });
+  //   }
+  //   return published;
+  // }
 
   private async signAndPublish(event: UnsignedEvent): Promise<boolean> {
     const signedEvent = await this.nostrService.signEvent(event);

--- a/src/app/services/utilities.service.ts
+++ b/src/app/services/utilities.service.ts
@@ -6,6 +6,7 @@ import { hexToBytes } from 'nostr-tools/utils';
 import { ProfilePointer } from 'nostr-tools/nip19';
 import { isPlatformBrowser } from '@angular/common';
 import { NostrTagKey } from '../standardized-tags';
+import { NostrRecord } from '../interfaces';
 
 @Injectable({
   providedIn: 'root',
@@ -31,9 +32,9 @@ export class UtilitiesService {
   private readonly platformId = inject(PLATFORM_ID);
   readonly isBrowser = signal(isPlatformBrowser(this.platformId));
 
-  constructor() { }
+  constructor() {}
 
-  toRecord(event: Event) {
+  toRecord(event: Event): NostrRecord {
     return {
       event,
       data: this.parseContent(event.content),


### PR DESCRIPTION
- Changed ProfileState service to listen for reposts (kind:6), collect them and return with .notes() call.
- Changed event component. The idea is that it could be used universally for reposts and 'normal' events:
  - added "Reposted.." header on top of the event card for repost events.
  - It now could be styled differently: outlined and plain. Outlined is a normal styling for MaterialUI card, and plain is without borders (e.g. for Event Page view).
- the component is now MatCard
- changed ProfileNotes component to use Event component to render notes instead of custom code
- Moved openEvent handler into LayoutService so it could be used from any component.
- Extracted ReplyButton component (which can be rendered as "comment" for article and "reply" for other events). It is not a part of Event Component (not the Event Page component)
- moved repostEvent out of UI components into RepostService and now calling it directly from UI components
- changed Repost button to show number of reposts (this yet to be improved)
- extracted EventHandler UI component to render the user profile, date and menu
- dropdown menu got removed from user-profile component in "thread" mode (it is always rendered now)
- changed bookmark component to open bookmarked articles in Article view

Closes #97 