### PR TITLE
feat: render event preview for nostr:nevent mentions 

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -156,7 +156,7 @@
 
     <mat-menu #menuApps="matMenu">
       @if (app.authenticated()) {
-      <button mat-menu-item (click)="layout.createNote()">
+      <button mat-menu-item (click)="eventService.createNote()">
         <mat-icon>create</mat-icon>
         <span>Create Note</span>
       </button>
@@ -293,7 +293,7 @@
       <!-- <mat-toolbar>
         <span>Profile</span>
         <span class="toolbar-spacer"></span>
-        
+
       </mat-toolbar> -->
       <div class="profile-content">
         <button
@@ -479,7 +479,7 @@
   <button mat-mini-fab color="primary" class="desktop-create-fab no-print" aria-label="Create new content"
     (click)="openCreateOptions()">
     <mat-icon>add</mat-icon>
-  </button> 
+  </button>
   } -->
 
   <!-- Mobile navigation footer - now outside of sidenav container -->

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -72,6 +72,7 @@ import { NavigationContextMenuComponent } from './components/navigation-context-
 import { nip47 } from 'nostr-tools';
 import { Wallets } from './services/wallets';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { EventService } from './services/event';
 
 interface NavItem {
   path: string;
@@ -138,6 +139,7 @@ export class App implements OnInit {
   nostrProtocol = inject(NostrProtocolService);
   publishQueue = inject(PublishQueueService);
   snackBar = inject(MatSnackBar);
+  eventService = inject(EventService);
   private readonly wallets = inject(Wallets);
   private readonly platform = inject(PLATFORM_ID);
   private readonly document = inject(DOCUMENT);

--- a/src/app/components/content/content.component.html
+++ b/src/app/components/content/content.component.html
@@ -1,62 +1,39 @@
 <div class="content-container" #contentContainer>
   @if (shouldShowContent()) {
-    @for (token of contentTokens(); track token.id) {
-      @if (token.type === 'text') {
-        <span>{{ token.content }}</span>
-      } @else if (token.type === 'linebreak') {
-        <br />
-      } @else if (token.type === 'emoji') {
-        <span class="emoji-token" [title]="token.content">{{
-          token.emoji
-        }}</span>
-      } @else if (token.type === 'nostr-mention') {
-        <span class="nostr-mention" (click)="onNostrMentionClick(token)">
-          &#64;{{ token.nostrData?.displayName }}
-        </span>
-      } @else if (token.type === 'url') {
-        <a [href]="token.content" target="_blank" rel="noopener noreferrer">{{
-          token.content
-        }}</a>
-      } @else if (token.type === 'youtube') {
-        <div class="media-container">
-          <iframe
-            width="560"
-            height="315"
-            [src]="token.processedUrl"
-            frameborder="0"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-            allowfullscreen
+    <app-note-content [contentTokens]="contentTokens()" />
+
+    @for (mention of eventMentions(); track mention.event.event.id) {
+      <mat-card>
+        <mat-card-header>
+          <app-user-profile
+            [pubkey]="mention.event.event.pubkey"
+            view="compact"
           >
-          </iframe>
-        </div>
-      } @else if (token.type === 'image') {
-        <div class="media-container">
-          <img
-            [src]="token.content"
-            alt="Content image"
-            loading="lazy"
-            (click)="openImageDialog(token.content)"
-            class="clickable-image"
-          />
-        </div>
-      } @else if (token.type === 'audio') {
-        <div class="media-container">
-          <audio controls>
-            <source [src]="token.content" />
-            Your browser does not support the audio element.
-          </audio>
-        </div>
-      } @else if (token.type === 'video') {
-        <div class="media-container">
-          <video controls>
-            <source
-              [src]="token.content"
-              type="video/{{ getVideoType(token.content) }}"
-            />
-            Your browser does not support the video element.
-          </video>
-        </div>
-      }
+            <a
+              class="date-link"
+              [matTooltip]="
+                mention.event.event.created_at * 1000 | date: 'medium'
+              "
+              matTooltipPosition="below"
+              tabindex="0"
+              role="button"
+              (click)="
+                layoutService.openEvent(
+                  mention.event.event.id,
+                  mention.event.event
+                )
+              "
+            >
+              {{ mention.event.event.created_at | ago }}
+            </a>
+          </app-user-profile>
+        </mat-card-header>
+        <mat-card-content>
+          <div class="content-container">
+            <app-note-content [contentTokens]="mention.contentTokens" />
+          </div>
+        </mat-card-content>
+      </mat-card>
     }
 
     @for (preview of socialPreviews(); track preview.url) {

--- a/src/app/components/content/note-content/note-content.component.html
+++ b/src/app/components/content/note-content/note-content.component.html
@@ -1,0 +1,59 @@
+@for (token of contentTokens(); track token.id) {
+  @if (token.type === 'text') {
+    <span>{{ token.content }} </span>
+  } @else if (token.type === 'linebreak') {
+    <br />
+  } @else if (token.type === 'emoji') {
+    <span class="emoji-token" [title]="token.content">{{ token.emoji }}</span>
+  } @else if (token.type === 'url') {
+    <a [href]="token.content" target="_blank" rel="noopener noreferrer">{{
+      token.content
+    }}</a>
+  } @else if (token.type === 'youtube') {
+    <div class="media-container">
+      <iframe
+        width="560"
+        height="315"
+        [src]="token.processedUrl"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen
+      >
+      </iframe>
+    </div>
+  } @else if (token.type === 'image') {
+    <div class="media-container">
+      <img
+        [src]="token.content"
+        alt="Content image"
+        loading="lazy"
+        (click)="openImageDialog(token.content)"
+        class="clickable-image"
+      />
+    </div>
+  } @else if (token.type === 'audio') {
+    <div class="media-container">
+      <audio controls>
+        <source [src]="token.content" />
+        Your browser does not support the audio element.
+      </audio>
+    </div>
+  } @else if (token.type === 'video') {
+    <div class="media-container">
+      <video controls>
+        <source
+          [src]="token.content"
+          type="video/{{ getVideoType(token.content) }}"
+        />
+        Your browser does not support the video element.
+      </video>
+    </div>
+  } @else if (
+    token.type === 'nostr-mention' &&
+    (token.nostrData?.type === 'npub' || token.nostrData?.type === 'nprofile')
+  ) {
+    <a class="nostr-mention" (click)="onNostrMentionClick(token)"
+      >&#64;{{ token.nostrData?.displayName }}</a
+    >
+  }
+}

--- a/src/app/components/content/note-content/note-content.component.ts
+++ b/src/app/components/content/note-content/note-content.component.ts
@@ -1,0 +1,78 @@
+import { Component, input, inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { UtilitiesService } from '../../../services/utilities.service';
+import { MatDialog } from '@angular/material/dialog';
+import { ImageDialogComponent } from '../../image-dialog/image-dialog.component';
+import { ContentToken } from '../../../services/parsing.service';
+
+@Component({
+  selector: 'app-note-content',
+  standalone: true,
+  imports: [],
+  templateUrl: './note-content.component.html',
+  styleUrl: './note-content.component.scss',
+})
+export class NoteContentComponent {
+  contentTokens = input<ContentToken[]>([]);
+  private router = inject(Router);
+  private utilities = inject(UtilitiesService);
+  private dialog = inject(MatDialog);
+
+  onNostrMentionClick(token: ContentToken) {
+    if (!token.nostrData) return;
+
+    const { type, data } = token.nostrData;
+
+    switch (type) {
+      case 'npub':
+      case 'nprofile': {
+        // Navigate to profile page
+        const record = data as Record<string, unknown>;
+        const pubkey =
+          type === 'npub' ? String(data) : String(record['pubkey'] || '');
+        this.router.navigate(['/p', this.utilities.getNpubFromPubkey(pubkey)]);
+        break;
+      }
+      case 'note':
+      default:
+        console.warn('Unsupported nostr URI type:', type);
+    }
+  }
+
+  getVideoType(url: string): string {
+    const extension = url.split('.').pop()?.split('?')[0]?.toLowerCase();
+    switch (extension) {
+      case 'mp4':
+        return 'mp4';
+      case 'webm':
+        return 'webm';
+      case 'mov':
+        return 'quicktime';
+      case 'avi':
+        return 'x-msvideo';
+      case 'wmv':
+        return 'x-ms-wmv';
+      case 'flv':
+        return 'x-flv';
+      case 'mkv':
+        return 'x-matroska';
+      default:
+        return 'mp4';
+    }
+  }
+
+  /**
+   * Opens an image dialog to view the image with zoom capabilities
+   */
+  openImageDialog(imageUrl: string): void {
+    console.log('Opening image dialog for URL:', imageUrl);
+    this.dialog.open(ImageDialogComponent, {
+      data: { imageUrl },
+      maxWidth: '95vw',
+      maxHeight: '95vh',
+      width: '100%',
+      height: '100%',
+      panelClass: 'image-dialog',
+    });
+  }
+}

--- a/src/app/components/create-options-sheet/create-options-sheet.component.ts
+++ b/src/app/components/create-options-sheet/create-options-sheet.component.ts
@@ -3,6 +3,7 @@ import { MatBottomSheetRef } from '@angular/material/bottom-sheet';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { LayoutService } from '../../services/layout.service';
+import { EventService } from '../../services/event';
 
 @Component({
   selector: 'app-create-options-sheet',
@@ -16,10 +17,15 @@ export class CreateOptionsSheetComponent {
     MatBottomSheetRef<CreateOptionsSheetComponent>
   );
   private layout = inject(LayoutService);
+  private eventService = inject(EventService);
 
   // Creation options
   createOptions = [
-    { label: 'Note', icon: 'create', action: () => this.layout.createNote() },
+    {
+      label: 'Note',
+      icon: 'create',
+      action: () => this.eventService.createNote(),
+    },
     {
       label: 'Article',
       icon: 'article',

--- a/src/app/components/event/event.component.ts
+++ b/src/app/components/event/event.component.ts
@@ -214,7 +214,7 @@ export class EventComponent {
   createQuote() {
     const record = this.repostedRecord() || this.record();
     if (!record) return;
-    this.layout.createNote({
+    this.eventService.createNote({
       quote: {
         id: record.event.id,
         pubkey: record.event.pubkey,

--- a/src/app/components/event/reply-button/reply-button.component.ts
+++ b/src/app/components/event/reply-button/reply-button.component.ts
@@ -3,7 +3,7 @@ import { Event, kinds } from 'nostr-tools';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { LayoutService } from '../../../services/layout.service';
+import { EventService } from '../../../services/event';
 
 @Component({
   selector: 'app-reply-button',
@@ -13,7 +13,7 @@ import { LayoutService } from '../../../services/layout.service';
   styleUrls: ['./reply-button.component.scss'],
 })
 export class ReplyButtonComponent {
-  private readonly layout = inject(LayoutService);
+  private readonly eventService = inject(EventService);
 
   event = input.required<Event>();
 
@@ -22,7 +22,7 @@ export class ReplyButtonComponent {
   );
 
   onClick(): void {
-    this.layout.createNote({
+    this.eventService.createNote({
       replyTo: {
         id: this.event().id,
         pubkey: this.event().pubkey,

--- a/src/app/components/user-profile/user-profile.component.scss
+++ b/src/app/components/user-profile/user-profile.component.scss
@@ -273,6 +273,32 @@
     }
   }
 
+  &.compact {
+    width: auto; // Changed from 100px to auto
+    flex-shrink: 0;
+
+    .user-profile-container {
+      justify-content: center; // Center the avatar
+      padding: 0; // Removed padding
+      width: auto; // Container should only be as wide as its content
+    }
+
+    .user-profile-avatar {
+      width: 24px;
+      height: 24px;
+      margin: 0; // Removed margin
+    }
+
+    .default-user-avatar {
+      font-size: 24px;
+    }
+
+    .user-profile-name {
+      font-size: 14px;
+      margin-top: 0; // Removed margin
+    }
+  }
+
   &.icon {
     width: auto; // Changed from 100px to auto
     flex-shrink: 0;

--- a/src/app/components/user-profile/user-profile.component.ts
+++ b/src/app/components/user-profile/user-profile.component.ts
@@ -371,6 +371,8 @@ export class UserProfileComponent implements AfterViewInit, OnDestroy {
         return '40px';
       case 'grid':
         return '36px';
+      case 'compact':
+        return '24px';
       default: // 'list'
         return '40px';
     }

--- a/src/app/interfaces.ts
+++ b/src/app/interfaces.ts
@@ -41,4 +41,5 @@ export type ViewMode =
   | 'list'
   | 'grid'
   | 'thread'
-  | 'icon';
+  | 'icon'
+  | 'compact';

--- a/src/app/services/event.ts
+++ b/src/app/services/event.ts
@@ -11,6 +11,11 @@ import { DiscoveryRelayServiceEx } from './relays/discovery-relay';
 import { UserDataFactoryService } from './user-data-factory.service';
 import { Cache } from './cache';
 import { UserDataService } from './user-data.service';
+import {
+  NoteEditorDialogComponent,
+  NoteEditorDialogData,
+} from '../components/note-editor-dialog/note-editor-dialog.component';
+import { MatDialog } from '@angular/material/dialog';
 
 export interface Reaction {
   emoji: string;
@@ -60,6 +65,7 @@ export class EventService {
   private readonly discoveryRelay = inject(DiscoveryRelayServiceEx);
   private readonly userDataFactory = inject(UserDataFactoryService);
   private readonly cache = inject(Cache);
+  private readonly dialog = inject(MatDialog);
 
   /**
    * Parse event tags to extract thread information
@@ -662,5 +668,21 @@ export class EventService {
       this.logger.error('Error loading reposts for event:', eventId, error);
       return [];
     }
+  }
+
+  // Handler methods for different creation types
+  createNote(data: NoteEditorDialogData = {}): void {
+    // Open note editor dialog
+    const dialogRef = this.dialog.open(NoteEditorDialogComponent, {
+      width: '600px',
+      maxWidth: '90vw',
+      data,
+    });
+
+    dialogRef.afterClosed().subscribe(result => {
+      if (result?.published) {
+        console.log('Note published successfully:', result.event);
+      }
+    });
   }
 }

--- a/src/app/services/layout.service.ts
+++ b/src/app/services/layout.service.ts
@@ -22,10 +22,6 @@ import { ProfileStateService } from './profile-state.service';
 import { LoginDialogComponent } from '../components/login-dialog/login-dialog.component';
 import { NostrRecord } from '../interfaces';
 import { AccountStateService } from './account-state.service';
-import {
-  NoteEditorDialogComponent,
-  NoteEditorDialogData,
-} from '../components/note-editor-dialog/note-editor-dialog.component';
 import { isPlatformBrowser } from '@angular/common';
 import { LocalStorageService } from './local-storage.service';
 
@@ -730,22 +726,6 @@ export class LayoutService implements OnDestroy {
 
   scrollToOptimalProfilePosition() {
     this.scrollToOptimalPosition(this.optimalProfilePosition);
-  }
-
-  // Handler methods for different creation types
-  createNote(data: NoteEditorDialogData = {}): void {
-    // Open note editor dialog
-    const dialogRef = this.dialog.open(NoteEditorDialogComponent, {
-      width: '600px',
-      maxWidth: '90vw',
-      data,
-    });
-
-    dialogRef.afterClosed().subscribe(result => {
-      if (result?.published) {
-        console.log('Note published successfully:', result.event);
-      }
-    });
   }
 
   createArticle(): void {

--- a/src/app/services/parsing.service.ts
+++ b/src/app/services/parsing.service.ts
@@ -1,12 +1,42 @@
 import { inject, Injectable } from '@angular/core';
 import { DataService } from './data.service';
 import { nip19 } from 'nostr-tools';
-import { ProfilePointer } from 'nostr-tools/nip19';
+import type { ProfilePointer } from 'nostr-tools/nip19';
 import { NostrService } from './nostr.service';
 import { StorageService } from './storage.service';
-import { NostrRecord } from '../interfaces';
+import type { NostrRecord } from '../interfaces';
 import { UtilitiesService } from './utilities.service';
 import { LoggerService } from './logger.service';
+import type { SafeResourceUrl } from '@angular/platform-browser';
+import { MediaPlayerService } from './media-player.service';
+
+export interface NostrData {
+  type: string;
+  // Narrow known shapes; keep flexible with index signature for unseen fields
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [k: string]: any;
+  displayName: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data: any;
+}
+
+export interface ContentToken {
+  id: number;
+  type:
+    | 'text'
+    | 'url'
+    | 'youtube'
+    | 'image'
+    | 'audio'
+    | 'video'
+    | 'linebreak'
+    | 'nostr-mention'
+    | 'emoji';
+  content: string;
+  nostrData?: NostrData;
+  emoji?: string;
+  processedUrl?: SafeResourceUrl; // For YouTube embed URLs that are pre-processed
+}
 
 @Injectable({
   providedIn: 'root',
@@ -17,6 +47,7 @@ export class ParsingService {
   storage = inject(StorageService);
   utilities = inject(UtilitiesService);
   logger = inject(LoggerService);
+  readonly media = inject(MediaPlayerService);
 
   // Cache for parsed nostr URIs to prevent repeated parsing
   private nostrUriCache = new Map<
@@ -161,5 +192,372 @@ export class ParsingService {
    */
   getNostrUriCacheSize(): number {
     return this.nostrUriCache.size;
+  }
+
+  private emojiMap: Record<string, string> = {
+    ':badge:': '🏅',
+    ':heart:': '❤️',
+    ':fire:': '🔥',
+    ':thumbs_up:': '👍',
+    ':thumbs_down:': '👎',
+    ':smile:': '😊',
+    ':laugh:': '😂',
+    ':cry:': '😢',
+    ':angry:': '😠',
+    ':confused:': '😕',
+    ':surprised:': '😮',
+    ':wink:': '😉',
+    ':cool:': '😎',
+    ':kiss:': '😘',
+    ':heart_eyes:': '😍',
+    ':thinking:': '🤔',
+    ':clap:': '👏',
+    ':pray:': '🙏',
+    ':muscle:': '💪',
+    ':ok_hand:': '👌',
+    ':wave:': '👋',
+    ':point_right:': '👉',
+    ':point_left:': '👈',
+    ':point_up:': '👆',
+    ':point_down:': '👇',
+    ':rocket:': '🚀',
+    ':star:': '⭐',
+    ':lightning:': '⚡',
+    ':sun:': '☀️',
+    ':moon:': '🌙',
+    ':rainbow:': '🌈',
+    ':coffee:': '☕',
+    ':beer:': '🍺',
+    ':wine:': '🍷',
+    ':pizza:': '🍕',
+    ':burger:': '🍔',
+    ':cake:': '🎂',
+    ':party:': '🎉',
+    ':gift:': '🎁',
+    ':music:': '🎵',
+    ':note:': '🎶',
+    ':phone:': '📱',
+    ':computer:': '💻',
+    ':email:': '📧',
+    ':lock:': '🔒',
+    ':unlock:': '🔓',
+    ':key:': '🔑',
+    ':money:': '💰',
+    ':dollar:': '💵',
+    ':euro:': '💶',
+    ':yen:': '💴',
+    ':pound:': '💷',
+    ':gem:': '💎',
+    ':crown:': '👑',
+    ':trophy:': '🏆',
+    ':medal:': '🏅',
+    ':first_place:': '🥇',
+    ':second_place:': '🥈',
+    ':third_place:': '🥉',
+    ':checkmark:': '✅',
+    ':cross:': '❌',
+    ':warning:': '⚠️',
+    ':stop:': '🛑',
+    ':green_circle:': '🟢',
+    ':red_circle:': '🔴',
+    ':yellow_circle:': '🟡',
+    ':blue_circle:': '🔵',
+    ':purple_circle:': '🟣',
+    ':orange_circle:': '🟠',
+    ':white_circle:': '⚪',
+    ':black_circle:': '⚫',
+  };
+
+  async parseContent(content: string): Promise<ContentToken[]> {
+    if (!content) return [];
+
+    // Replace line breaks with placeholders
+    const processedContent = content.replace(/\n/g, '##LINEBREAK##');
+
+    // Regex for different types of content - updated to avoid capturing trailing LINEBREAK placeholders
+    // URL regex: capture potential trailing punctuation so we can trim logic-smart (e.g. parentheses, commas, periods)
+    const urlRegex =
+      /(https?:\/\/[^\s##)\]\}>]+)(?=\s|##LINEBREAK##|$|[),.;!?:])/g;
+    const youtubeRegex =
+      /(https?:\/\/)?(www\.)?(youtube\.com\/watch\?v=|youtu\.be\/)([a-zA-Z0-9_-]{11})(?=\s|##LINEBREAK##|$)/g;
+    const imageRegex =
+      /(https?:\/\/[^\s##]+\.(jpg|jpeg|png|gif|webp)(\?[^\s##]*)?(?=\s|##LINEBREAK##|$))/gi;
+    const audioRegex =
+      /(https?:\/\/[^\s##]+\.(mp3|wav|ogg)(\?[^\s##]*)?(?=\s|##LINEBREAK##|$))/gi;
+    const videoRegex =
+      /(https?:\/\/[^\s##]+\.(mp4|webm|mov|avi|wmv|flv|mkv)(\?[^\s##]*)?(?=\s|##LINEBREAK##|$))/gi;
+    const nostrRegex =
+      /(nostr:(?:npub|nprofile|note|nevent|naddr)1[a-zA-Z0-9]+)(?=\s|##LINEBREAK##|$|[^\w])/g;
+    const emojiRegex = /(:[a-zA-Z_]+:)/g;
+
+    // Split content and generate tokens
+    const tokens: ContentToken[] = [];
+    let lastIndex = 0;
+
+    // Find all matches and their positions
+    const matches: {
+      start: number;
+      end: number;
+      content: string;
+      type: ContentToken['type'];
+      nostrData?: NostrData;
+      emoji?: string;
+      processedUrl?: SafeResourceUrl;
+    }[] = [];
+
+    // Find emoji codes first (highest priority after nostr)
+    let match: RegExpExecArray | null;
+    while ((match = emojiRegex.exec(processedContent)) !== null) {
+      const emojiCode = match[0];
+      const emoji = this.emojiMap[emojiCode];
+      if (emoji) {
+        matches.push({
+          start: match.index,
+          end: match.index + match[0].length,
+          content: emojiCode,
+          type: 'emoji',
+          emoji,
+        });
+      }
+    }
+
+    // Find Nostr URIs (highest priority) - collect first, then batch process
+    const nostrMatches: {
+      match: RegExpExecArray;
+      index: number;
+      length: number;
+    }[] = [];
+    while ((match = nostrRegex.exec(processedContent)) !== null) {
+      nostrMatches.push({
+        match,
+        index: match.index,
+        length: match[0].length,
+      });
+    }
+
+    // Batch process nostr URIs to avoid sequential awaits
+    const nostrDataPromises = nostrMatches.map(async nostrMatch => {
+      try {
+        const nostrData = await this.parseNostrUri(nostrMatch.match[0]);
+        return {
+          ...nostrMatch,
+          nostrData,
+        };
+      } catch (error) {
+        console.warn('Error parsing nostr URI:', nostrMatch.match[0], error);
+        return {
+          ...nostrMatch,
+          nostrData: null,
+        };
+      }
+    });
+
+    // Wait for all nostr URIs to be processed
+    const processedNostrMatches = await Promise.all(nostrDataPromises);
+
+    // Add valid nostr matches to the matches array
+    for (const { match, index, length, nostrData } of processedNostrMatches) {
+      if (nostrData) {
+        matches.push({
+          start: index,
+          end: index + length,
+          content: match[0],
+          type: 'nostr-mention',
+          nostrData,
+        });
+      }
+    }
+
+    // Find YouTube URLs
+    while ((match = youtubeRegex.exec(processedContent)) !== null) {
+      // Pre-process the YouTube URL to avoid repeated calls in template
+      const youtubeUrl = match[0];
+      const processedUrl = this.media.getYouTubeEmbedUrl()(youtubeUrl);
+
+      matches.push({
+        start: match.index,
+        end: match.index + match[0].length,
+        content: youtubeUrl,
+        type: 'youtube',
+        processedUrl: processedUrl,
+      });
+    }
+
+    // Find image URLs
+    imageRegex.lastIndex = 0;
+    while ((match = imageRegex.exec(processedContent)) !== null) {
+      matches.push({
+        start: match.index,
+        end: match.index + match[0].length,
+        content: match[0],
+        type: 'image',
+      });
+    }
+
+    // Find video URLs
+    videoRegex.lastIndex = 0;
+    while ((match = videoRegex.exec(processedContent)) !== null) {
+      matches.push({
+        start: match.index,
+        end: match.index + match[0].length,
+        content: match[0],
+        type: 'video',
+      });
+    }
+
+    // Find audio URLs
+    audioRegex.lastIndex = 0;
+    while ((match = audioRegex.exec(processedContent)) !== null) {
+      matches.push({
+        start: match.index,
+        end: match.index + match[0].length,
+        content: match[0],
+        type: 'audio',
+      });
+    }
+
+    // Find remaining URLs
+    urlRegex.lastIndex = 0;
+    while ((match = urlRegex.exec(processedContent)) !== null) {
+      let rawUrl = match[0];
+      const start = match.index;
+
+      // Trim trailing punctuation that is unlikely part of the URL
+      const trailingPattern = /[)\],;!?.]+$/;
+      while (trailingPattern.test(rawUrl)) {
+        const lastChar = rawUrl.slice(-1);
+        if (lastChar === '/' || lastChar === '#') break; // keep structural chars
+        if (lastChar === ')') {
+          const openCount = (rawUrl.match(/\(/g) || []).length;
+          const closeCount = (rawUrl.match(/\)/g) || []).length;
+          if (closeCount <= openCount) break;
+        }
+        if (lastChar === ']') {
+          const openCount = (rawUrl.match(/\[/g) || []).length;
+          const closeCount = (rawUrl.match(/\]/g) || []).length;
+          if (closeCount <= openCount) break;
+        }
+        rawUrl = rawUrl.slice(0, -1);
+      }
+
+      if (!rawUrl) continue;
+
+      const isSpecialType = matches.some(
+        m => m.start === start && m.end === start + rawUrl.length
+      );
+      if (!isSpecialType) {
+        matches.push({
+          start,
+          end: start + rawUrl.length,
+          content: rawUrl,
+          type: 'url',
+        });
+      }
+    }
+
+    // Sort matches by their starting position
+    matches.sort((a, b) => a.start - b.start);
+
+    // Process text segments and matches with deterministic IDs
+    for (const match of matches) {
+      // Add text segment before the match
+      if (match.start > lastIndex) {
+        const textSegment = processedContent.substring(lastIndex, match.start);
+        this.processTextSegment(textSegment, tokens, lastIndex);
+      }
+
+      // Add the match as a token with deterministic ID based on position and content
+      const tokenId = this.generateStableTokenId(
+        match.start,
+        match.content,
+        match.type
+      );
+      const token: ContentToken = {
+        id: tokenId,
+        type: match.type,
+        content: match.content,
+      };
+
+      if (match.nostrData) {
+        token.nostrData = match.nostrData;
+      }
+
+      if (match.emoji) {
+        token.emoji = match.emoji;
+      }
+
+      if (match.processedUrl) {
+        token.processedUrl = match.processedUrl;
+      }
+
+      tokens.push(token);
+
+      lastIndex = match.end;
+    }
+
+    // Add remaining text after the last match
+    if (lastIndex < processedContent.length) {
+      const textSegment = processedContent.substring(lastIndex);
+      this.processTextSegment(textSegment, tokens, lastIndex);
+    }
+
+    return tokens;
+  }
+  private processTextSegment(
+    segment: string,
+    tokens: ContentToken[],
+    basePosition: number
+  ): void {
+    // Process line breaks in text segments
+    const parts = segment.split('##LINEBREAK##');
+
+    for (let i = 0; i < parts.length; i++) {
+      // Only add text token if there's actual content (not empty string)
+      if (parts[i].trim()) {
+        const tokenId = this.generateStableTokenId(
+          basePosition + i,
+          parts[i].trim(),
+          'text'
+        );
+        tokens.push({
+          id: tokenId,
+          type: 'text',
+          content: parts[i].trim(),
+        });
+      }
+
+      // Add a line break token after each part except the last one
+      if (i < parts.length - 1) {
+        const linebreakId = this.generateStableTokenId(
+          basePosition + i,
+          '',
+          'linebreak'
+        );
+        tokens.push({
+          id: linebreakId,
+          type: 'linebreak',
+          content: '',
+        });
+      }
+    }
+  }
+
+  /**
+   * Generate a stable token ID based on position and content
+   */
+  private generateStableTokenId(
+    position: number,
+    content: string,
+    type: string
+  ): number {
+    // Create a simple hash from position, content, and type
+    let hash = 0;
+    const str = `${position}-${type}-${content}`;
+    for (let i = 0; i < str.length; i++) {
+      const char = str.charCodeAt(i);
+      hash = (hash << 5) - hash + char;
+      hash = hash & hash; // Convert to 32-bit integer
+    }
+    return Math.abs(hash);
   }
 }


### PR DESCRIPTION
Changes:
- extracted NoteContent component from Content component. It is
meant to render only immediate content of the note (no URL previews or
other note mentions)
- changed Content component to render only npub and nprofile mentions (using NoteContent component)
- changed Content component to render nostr:nevent mentions (if any) separately after the main content.
For that we get referenced event, parse its content and use NoteContent component to render it. Also
using special "compact" view for UserProfile component to render the header for referenced event.
- to make NoteContent work we extracted content parsing logic from Content component into ParsingService.
This way we can reuse it to parse content of both event and referenced events.
- moved 'createNote' method from LayoutService into EventService to avoid fix circular dependency

Closes #88 