### PR TITLE
feat: add event menu to Article Page

### DIFF
--- a/src/app/components/event/event-menu/event-menu.component.html
+++ b/src/app/components/event/event-menu/event-menu.component.html
@@ -1,6 +1,23 @@
-<button mat-icon-button [matMenuTriggerFor]="menu" aria-label="More options" (click)="$event.stopPropagation()">
-  <mat-icon>more_vert</mat-icon>
-</button>
+@if (view() === 'full') {
+  <button
+    mat-button
+    [matMenuTriggerFor]="menu"
+    aria-label="More options"
+    (click)="$event.stopPropagation()"
+  >
+    <mat-icon>more_vert</mat-icon>
+    More options
+  </button>
+} @else {
+  <button
+    mat-icon-button
+    [matMenuTriggerFor]="menu"
+    aria-label="More options"
+    (click)="$event.stopPropagation()"
+  >
+    <mat-icon>more_vert</mat-icon>
+  </button>
+}
 <mat-menu #menu="matMenu">
   <button mat-menu-item (click)="layout.copyToClipboard(eventLink(), 'text')">
     <mat-icon>link</mat-icon>
@@ -29,10 +46,10 @@
   </button>
   <mat-divider></mat-divider>
   @if (isOurEvent()) {
-  <button mat-menu-item (click)="deleteEvent()">
-    <mat-icon>delete</mat-icon>
-    Delete Event
-  </button>
+    <button mat-menu-item (click)="deleteEvent()">
+      <mat-icon>delete</mat-icon>
+      Delete Event
+    </button>
   }
   <button mat-menu-item (click)="layout.publishEvent(event())">
     <mat-icon>publish</mat-icon>
@@ -44,9 +61,9 @@
     Report Content
   </button>
   @if (event().pubkey !== accountState.pubkey()) {
-  <button mat-menu-item (click)="accountState.mutePubkey(event().pubkey);">
-    <mat-icon>block</mat-icon>
-    <span>Block User</span>
-  </button>
+    <button mat-menu-item (click)="accountState.mutePubkey(event().pubkey)">
+      <mat-icon>block</mat-icon>
+      <span>Block User</span>
+    </button>
   }
 </mat-menu>

--- a/src/app/components/event/event-menu/event-menu.component.scss
+++ b/src/app/components/event/event-menu/event-menu.component.scss
@@ -1,0 +1,4 @@
+:host {
+  text-align: center;
+  --mat-button-text-icon-spacing: 4px;
+}

--- a/src/app/components/event/event-menu/event-menu.component.ts
+++ b/src/app/components/event/event-menu/event-menu.component.ts
@@ -18,11 +18,19 @@ import {
 } from '../../confirm-dialog/confirm-dialog.component';
 import { LayoutService } from '../../../services/layout.service';
 import type { ReportTarget } from '../../../services/reporting.service';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-event-menu',
   standalone: true,
-  imports: [MatIconModule, MatButtonModule, MatTooltipModule, MatDividerModule, MatMenuModule],
+  imports: [
+    CommonModule,
+    MatIconModule,
+    MatButtonModule,
+    MatTooltipModule,
+    MatDividerModule,
+    MatMenuModule,
+  ],
   templateUrl: './event-menu.component.html',
   styleUrl: './event-menu.component.scss',
 })
@@ -35,6 +43,7 @@ export class EventMenuComponent {
   snackBar = inject(MatSnackBar);
 
   event = input.required<Event>();
+  view = input<'icon' | 'full'>('icon');
 
   record = signal<NostrRecord | null>(null);
 

--- a/src/app/pages/article/article.component.html
+++ b/src/app/pages/article/article.component.html
@@ -119,6 +119,8 @@
           <mat-icon>comment</mat-icon>
           Comment
         </button>
+
+        <app-event-menu [event]="article" [view]="'full'"></app-event-menu>
       </div>
     </footer>
   </div>

--- a/src/app/pages/article/article.component.ts
+++ b/src/app/pages/article/article.component.ts
@@ -29,6 +29,7 @@ import { Cache } from '../../services/cache';
 import { UserDataService } from '../../services/user-data.service';
 import { Subscription } from 'rxjs';
 import { RepostButtonComponent } from '../../components/event/repost-button/repost-button.component';
+import { EventMenuComponent } from '../../components/event/event-menu/event-menu.component';
 
 @Component({
   selector: 'app-article',
@@ -45,6 +46,7 @@ import { RepostButtonComponent } from '../../components/event/repost-button/repo
     CommonModule,
     RouterModule,
     RepostButtonComponent,
+    EventMenuComponent,
   ],
   templateUrl: './article.component.html',
   styleUrl: './article.component.scss',

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -987,6 +987,9 @@ app-media-queue .media-list mat-list {
 
   .mat-icon {
     margin: 0;
+    height: 24px;
+    width: 24px;
+    font-size: 24px;
   }
 }
 


### PR DESCRIPTION
So that we can republish, copy id, delete, report etc

Changes:
- EventMenu componenent now has optional input argument 'view' which can be 'icon' or 'full'. The latter renders the label as well. Default view is 'icon'