### PR TITLE
fix: Improve mutual following text grammar and clarity

### DIFF
--- a/src/app/components/user-profile/hover-card/profile-hover-card.component.ts
+++ b/src/app/components/user-profile/hover-card/profile-hover-card.component.ts
@@ -253,19 +253,19 @@ export class ProfileHoverCardComponent {
       .filter(n => n !== 'Unknown');
 
     if (count === 1) {
-      return names.length > 0 ? `Also follow ${names[0]}` : '1 mutual follow';
+      return names.length > 0 ? `Also follows ${names[0]}` : '1 follower in common';
     } else if (count === 2) {
       return names.length === 2
-        ? `Also follow ${names[0]} and ${names[1]}`
-        : `${count} mutual follows`;
+        ? `Also follows ${names[0]} and ${names[1]}`
+        : `${count} followers in common`;
     } else {
       const remaining = count - names.length;
       if (names.length === 0) {
-        return `${count} mutual follows`;
+        return `${count} followers in common`;
       } else if (names.length === 1) {
-        return `Also follow ${names[0]} and ${remaining} other${remaining !== 1 ? 's' : ''}`;
+        return `Also follows ${names[0]} and ${remaining} other${remaining !== 1 ? 's' : ''}`;
       } else {
-        return `Also follow ${names[0]}, ${names[1]} and ${remaining} other${remaining !== 1 ? 's' : ''}`;
+        return `Also follows ${names[0]}, ${names[1]} and ${remaining} other${remaining !== 1 ? 's' : ''}`;
       }
     }
   }


### PR DESCRIPTION
## Summary
- Changed "Also follow" to "Also follows" for grammatical correctness (3rd person singular)
- Replaced "mutual follow/follows" with "followers in common" for better clarity and consistency with social media conventions

## Changes
The profile hover card mutual following text has been updated to be more grammatically correct and clearer:

**Before:**
- "Also follow Alice"
- "2 mutual follows"

**After:**
- "Also follows Alice" 
- "2 followers in common"

This makes it clear that the text is a statement about the hovered profile (they follow these people), not an imperative command. The "followers in common" phrasing is more natural and matches how other social platforms communicate shared connections.

## Test plan
- [ ] Verify hover card displays correct text for 1 mutual follower
- [ ] Verify hover card displays correct text for 2 mutual followers
- [ ] Verify hover card displays correct text for 3+ mutual followers
- [ ] Check fallback text when profile names cannot be loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)