### PR TITLE
feat: align kind 31871 attestation tags with latest NIP

### DIFF
--- a/src/app/components/event-types/wot-event.component.html
+++ b/src/app/components/event-types/wot-event.component.html
@@ -25,22 +25,6 @@
       </mat-chip>
     </mat-chip-set>
     }
-
-    @if (validity()) {
-    <mat-chip-set>
-      <mat-chip class="validity-chip" [class.positive]="isPositive()" [class.negative]="isNegative()"
-        [matTooltip]="'Validity: ' + validity()">
-        @if (isPositive()) {
-        <mat-icon matChipAvatar>check_circle</mat-icon>
-        } @else if (isNegative()) {
-        <mat-icon matChipAvatar>cancel</mat-icon>
-        } @else {
-        <mat-icon matChipAvatar>help</mat-icon>
-        }
-        {{ validityDisplay() }}
-      </mat-chip>
-    </mat-chip-set>
-    }
   </div>
 
   @if (referencedEvents().length > 0) {
@@ -96,23 +80,6 @@
             </mat-card-content>
           </mat-card>
         }
-      }
-    </div>
-  </div>
-  }
-
-  @if (referencedPubkeys().length > 0) {
-  <div class="wot-section">
-    <div class="section-label">
-      <mat-icon>person</mat-icon>
-      <span>Referenced Users</span>
-    </div>
-    <div class="users-grid">
-      @for (pubkey of referencedPubkeys(); track pubkey) {
-      <div class="user-item" (click)="navigateToProfile(pubkey)" (keyup.enter)="navigateToProfile(pubkey)"
-        (keyup.space)="navigateToProfile(pubkey)" tabindex="0" role="button">
-        <app-user-profile [pubkey]="pubkey" [view]="'compact'"></app-user-profile>
-      </div>
       }
     </div>
   </div>

--- a/src/app/components/event-types/wot-event.component.ts
+++ b/src/app/components/event-types/wot-event.component.ts
@@ -92,13 +92,6 @@ export class WotEventComponent {
     this.fetchReferencedEvents(refs);
   });
 
-  /** Referenced pubkeys from p-tags */
-  referencedPubkeys = computed(() => {
-    return this.event().tags
-      .filter(t => t[0] === 'p' && !!t[1])
-      .map(t => t[1]);
-  });
-
   /** Status tag (s) - e.g., "verified", "spam", "trusted" */
   status = computed(() => {
     const tag = this.event().tags.find(t => t[0] === 's');
@@ -107,15 +100,6 @@ export class WotEventComponent {
 
   /** Capitalized status for display */
   statusDisplay = computed(() => this.capitalize(this.status()));
-
-  /** Validity tag (v) - e.g., "valid", "invalid" */
-  validity = computed(() => {
-    const tag = this.event().tags.find(t => t[0] === 'v');
-    return tag?.[1] || '';
-  });
-
-  /** Capitalized validity for display */
-  validityDisplay = computed(() => this.capitalize(this.validity()));
 
   /** Client that created this attestation */
   client = computed(() => {
@@ -129,15 +113,13 @@ export class WotEventComponent {
   /** Whether this is a positive/trust attestation */
   isPositive = computed(() => {
     const s = this.status().toLowerCase();
-    const v = this.validity().toLowerCase();
-    return s === 'verified' || s === 'trusted' || s === 'safe' || v === 'valid' || v === 'trusted';
+    return s === 'verified' || s === 'trusted' || s === 'safe' || s === 'valid';
   });
 
   /** Whether this is a negative/distrust attestation */
   isNegative = computed(() => {
     const s = this.status().toLowerCase();
-    const v = this.validity().toLowerCase();
-    return s === 'spam' || s === 'bot' || s === 'malicious' || s === 'blocked' || v === 'invalid' || v === 'spam';
+    return s === 'spam' || s === 'bot' || s === 'malicious' || s === 'blocked' || s === 'invalid';
   });
 
   /** Icon to display based on status */
@@ -147,9 +129,9 @@ export class WotEventComponent {
     return 'shield';
   });
 
-  /** All custom tags that aren't standard structural ones (d, e, p, s, v, client) */
+  /** All custom tags that aren't standard structural ones (d, e, s, client) */
   extraTags = computed(() => {
-    const knownTags = new Set(['d', 'e', 'p', 's', 'v', 'client']);
+    const knownTags = new Set(['d', 'e', 's', 'client']);
     return this.event().tags
       .filter(t => !knownTags.has(t[0]) && !!t[1])
       .map(t => ({ key: t[0], value: t[1] }));
@@ -171,11 +153,6 @@ export class WotEventComponent {
     if (ref.nevent) {
       this.layout.openEventAsPrimary(ref.nevent);
     }
-  }
-
-  /** Navigate to a user profile */
-  navigateToProfile(pubkey: string): void {
-    this.layout.navigateToProfile(pubkey);
   }
 
   /** Capitalize the first letter of each word */


### PR DESCRIPTION
## Summary
- update Web of Trust attestation (kind 31871) rendering to use only the `s` tag and remove `v` tag handling
- remove kind 31871 `p` tag handling from the event UI (no referenced-users section)
- rely on standard event `content` for attestation text and keep non-structural tags visible under additional tags

## Notes
- this intentionally drops backward compatibility for old attestation tag layouts, per request