### PR TITLE
fix(communities): shorten moderator chip label to 'mods'

### DIFF
--- a/src/app/pages/communities/communities.component.html
+++ b/src/app/pages/communities/communities.component.html
@@ -60,7 +60,7 @@
               <mat-chip-set class="community-chips">
                 <mat-chip>
                   <mat-icon matChipAvatar>shield</mat-icon>
-                  {{ community.moderators.length }} moderator{{ community.moderators.length !== 1 ? 's' : '' }}
+                  {{ community.moderators.length }} mod{{ community.moderators.length !== 1 ? 's' : '' }}
                 </mat-chip>
               </mat-chip-set>
               }

--- a/src/app/pages/community/community.component.html
+++ b/src/app/pages/community/community.component.html
@@ -85,7 +85,7 @@
       <mat-chip-set>
         <mat-chip>
           <mat-icon matChipAvatar>shield</mat-icon>
-          {{ community()!.moderators.length }} moderator{{ community()!.moderators.length !== 1 ? 's' : '' }}
+          {{ community()!.moderators.length }} mod{{ community()!.moderators.length !== 1 ? 's' : '' }}
         </mat-chip>
       </mat-chip-set>
       }


### PR DESCRIPTION
## Summary
- Shortened the moderator chip label from "N moderator(s)" to "N mod(s)" on the communities list and community detail pages
- Gives more horizontal space for the owner profile display