### PR TITLE
Improve clips video preload

### DIFF
--- a/src/app/components/inline-video-player/inline-video-player.component.spec.ts
+++ b/src/app/components/inline-video-player/inline-video-player.component.spec.ts
@@ -143,4 +143,21 @@ describe('InlineVideoPlayerComponent', () => {
       expect(component.toggleMute).toBeDefined();
     });
   });
+
+  describe('preload mode', () => {
+    it('should default to metadata preload', () => {
+      const video = fixture.nativeElement.querySelector('video') as HTMLVideoElement;
+
+      expect(video.getAttribute('preload')).toBe('metadata');
+    });
+
+    it('should allow eager preload for clip playback', () => {
+      fixture.componentRef.setInput('preload', 'auto');
+      fixture.detectChanges();
+
+      const video = fixture.nativeElement.querySelector('video') as HTMLVideoElement;
+
+      expect(video.getAttribute('preload')).toBe('auto');
+    });
+  });
 });

--- a/src/app/components/inline-video-player/inline-video-player.component.ts
+++ b/src/app/components/inline-video-player/inline-video-player.component.ts
@@ -34,6 +34,8 @@ const DEFAULT_INLINE_VIDEO_CONTROLS_CONFIG: VideoControlsConfig = {
   showDownload: true,
 };
 
+type VideoPreloadMode = 'none' | 'metadata' | 'auto';
+
 @Component({
   selector: 'app-inline-video-player',
   imports: [
@@ -64,6 +66,7 @@ export class InlineVideoPlayerComponent implements AfterViewInit, OnDestroy {
   autoplay = input<boolean>(false);
   muted = input<boolean>(false);
   loop = input<boolean>(false);
+  preload = input<VideoPreloadMode>('metadata');
   blurred = input<boolean>(false);
   ignoreGlobalMutePreference = input<boolean>(false);
   objectFit = input<'contain' | 'cover'>('contain');
@@ -120,7 +123,7 @@ export class InlineVideoPlayerComponent implements AfterViewInit, OnDestroy {
 
   effectivePoster = computed(() => this.poster() || this.generatedPoster() || undefined);
 
-  effectivePreload = computed<'metadata'>(() => 'metadata');
+  effectivePreload = computed<VideoPreloadMode>(() => this.preload());
 
   effectiveControlsConfig = computed<VideoControlsConfig>(() => ({
     ...DEFAULT_INLINE_VIDEO_CONTROLS_CONFIG,

--- a/src/app/pages/clips/clips-video-card/clips-video-card.component.html
+++ b/src/app/pages/clips/clips-video-card/clips-video-card.component.html
@@ -1,8 +1,8 @@
 <div class="clip-card">
   @if (videoUrl()) {
   <app-inline-video-player class="clip-player" [src]="videoUrl()" [poster]="posterUrl()" [autoplay]="active()"
-    [muted]="false" [ignoreGlobalMutePreference]="true" [loop]="true" [objectFit]="objectFitMode()"
-    [expectedDim]="videoDim()" [fillContainer]="true" [controlsConfig]="{
+    [muted]="false" [ignoreGlobalMutePreference]="true" [loop]="true" [preload]="preload()"
+    [objectFit]="objectFitMode()" [expectedDim]="videoDim()" [fillContainer]="true" [controlsConfig]="{
       showQuality: false,
       showPlaybackRate: false,
       showCast: false,

--- a/src/app/pages/clips/clips-video-card/clips-video-card.component.ts
+++ b/src/app/pages/clips/clips-video-card/clips-video-card.component.ts
@@ -47,6 +47,7 @@ const INTERACTION_REFRESH_INTERVAL_MS = 15000;
 export class ClipsVideoCardComponent implements OnDestroy {
   event = input.required<Event>();
   active = input<boolean>(true);
+  preload = input<'none' | 'metadata' | 'auto'>('metadata');
 
   commentsClick = output<void>();
 

--- a/src/app/pages/clips/clips.component.html
+++ b/src/app/pages/clips/clips.component.html
@@ -148,13 +148,18 @@
         <div class="swipe-card swipe-card-current" [class.animating]="isCardAnimating('following')"
           [style.transform]="getCardTransform('following')">
           <app-clips-video-card [event]="clip" [active]="selectedTabIndex() === 1"
-            (commentsClick)="openComments(clip)" />
+            preload="auto" (commentsClick)="openComments(clip)" />
         </div>
         @if (hasSwipePreview('following') && getSwipePreviewClip('following'); as previewClip) {
         <div class="swipe-card swipe-card-preview" [class.animating]="isCardAnimating('following')"
           [style.transform]="getSwipePreviewTransform('following')">
-          <app-clips-video-card [event]="previewClip" [active]="false" />
+          <app-clips-video-card [event]="previewClip" [active]="false" preload="auto" />
         </div>
+        }
+      </div>
+      <div class="clip-preloaders" aria-hidden="true">
+        @for (preloadClip of followingPreloadClips(); track preloadClip.id) {
+        <video class="clip-preloader" [src]="getClipVideoUrl(preloadClip)" preload="auto" [muted]="true" playsinline></video>
         }
       </div>
       <div class="desktop-nav-buttons">
@@ -205,13 +210,18 @@
         <div class="swipe-card swipe-card-current" [class.animating]="isCardAnimating('foryou')"
           [style.transform]="getCardTransform('foryou')">
           <app-clips-video-card [event]="clip" [active]="selectedTabIndex() === 2"
-            (commentsClick)="openComments(clip)" />
+            preload="auto" (commentsClick)="openComments(clip)" />
         </div>
         @if (hasSwipePreview('foryou') && getSwipePreviewClip('foryou'); as previewClip) {
         <div class="swipe-card swipe-card-preview" [class.animating]="isCardAnimating('foryou')"
           [style.transform]="getSwipePreviewTransform('foryou')">
-          <app-clips-video-card [event]="previewClip" [active]="false" />
+          <app-clips-video-card [event]="previewClip" [active]="false" preload="auto" />
         </div>
+        }
+      </div>
+      <div class="clip-preloaders" aria-hidden="true">
+        @for (preloadClip of forYouPreloadClips(); track preloadClip.id) {
+        <video class="clip-preloader" [src]="getClipVideoUrl(preloadClip)" preload="auto" [muted]="true" playsinline></video>
         }
       </div>
       <div class="desktop-nav-buttons">

--- a/src/app/pages/clips/clips.component.scss
+++ b/src/app/pages/clips/clips.component.scss
@@ -230,6 +230,20 @@
   pointer-events: none;
 }
 
+.clip-preloaders {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.clip-preloader {
+  width: 1px;
+  height: 1px;
+}
+
 .swipe-position {
   position: absolute;
   top: 1rem;

--- a/src/app/pages/clips/clips.component.ts
+++ b/src/app/pages/clips/clips.component.ts
@@ -214,6 +214,9 @@ export class ClipsComponent implements OnInit, OnDestroy {
     return clips[index] || null;
   });
 
+  followingPreloadClips = computed(() => this.getAdjacentPreloadClips(this.followingClips(), this.followingIndex()));
+  forYouPreloadClips = computed(() => this.getAdjacentPreloadClips(this.forYouClips(), this.forYouIndex()));
+
   async ngOnInit(): Promise<void> {
     this.pendingFollowingRestoreEventId = this.accountLocalState.getClipsLastFollowingEventId(this.getAccountKey()) || null;
     this.pendingForYouRestoreEventId = this.accountLocalState.getClipsLastForYouEventId(this.getAccountKey()) || null;
@@ -275,6 +278,22 @@ export class ClipsComponent implements OnInit, OnDestroy {
     if (!imetaTag) return '';
     const parsed = this.utilities.parseImetaTag(imetaTag, true);
     return parsed['image'] || '';
+  }
+
+  getClipVideoUrl(event: Event): string {
+    const imetaTags = event.tags.filter(tag => tag[0] === 'imeta');
+
+    for (const imetaTag of imetaTags) {
+      const parsed = this.utilities.parseImetaTag(imetaTag, true);
+      const mimeType = parsed['m'] || '';
+      const url = parsed['url'] || '';
+
+      if (url && (!mimeType || mimeType.startsWith('video/'))) {
+        return url;
+      }
+    }
+
+    return '';
   }
 
   getClipTitle(event: Event): string {
@@ -1007,6 +1026,28 @@ export class ClipsComponent implements OnInit, OnDestroy {
   private resetExploreLimit(): void {
     this.exploreLimit.set(EXPLORE_PAGE_SIZE);
     this.refreshExploreAutoLoadObserver();
+  }
+
+  private getAdjacentPreloadClips(clips: Event[], currentIndex: number): Event[] {
+    if (clips.length <= 1) {
+      return [];
+    }
+
+    const candidateIndexes = [currentIndex + 1, currentIndex - 1, currentIndex + 2];
+    const seen = new Set<string>();
+    const candidates: Event[] = [];
+
+    for (const index of candidateIndexes) {
+      const clip = clips[index];
+      if (!clip || seen.has(clip.id) || !this.getClipVideoUrl(clip)) {
+        continue;
+      }
+
+      seen.add(clip.id);
+      candidates.push(clip);
+    }
+
+    return candidates;
   }
 
   private advanceByKeyboard(mode: SwipeMode, delta: number): void {


### PR DESCRIPTION
**Summary**

Improves `/clips` video startup by eagerly preloading the active clip and warming nearby clips before swipe navigation.

**Changes**

- Added configurable `preload` support to `app-inline-video-player`
- Set active and preview clip cards to use `preload="auto"`
- Added hidden muted preloaders for adjacent clips: next, previous, and next+1
- Added regression coverage for the inline player preload mode

**Testing**

- `npx tsc --noEmit --project tsconfig.app.json`
- `npm run build` with Node `24.15.0`
- Manual Playwright probe on `/clips` confirmed active video plus adjacent preloaders issue media requests early

**Notes**

Some startup delay may still come from media origin failures or slow host responses. A follow-up could consider muted autoplay with an explicit unmute UX.